### PR TITLE
SFCWater Fixes

### DIFF
--- a/ED/src/dynamics/canopy_struct_dynamics.f90
+++ b/ED/src/dynamics/canopy_struct_dynamics.f90
@@ -247,6 +247,7 @@ module canopy_struct_dynamics
       logical        :: dry_grasses  ! Flag to check whether LAI+WAI is zero    [      ---]
       real           :: tai_drygrass ! TAI for when a grass-only patch is dry   [    m2/m2]
       real           :: c3_lad       ! c3 * lad for estimating drag coefficient [      ---]
+      real           :: snowfac_can  ! percent vertical canopy covered in snow
       !----- External functions. ----------------------------------------------------------!
       real(kind=4), external :: cbrt ! Cubic root that works for negative numbers
       !------------------------------------------------------------------------------------!
@@ -291,6 +292,14 @@ module canopy_struct_dynamics
       !------------------------------------------------------------------------------------!
 
 
+      !------------------------------------------------------------------------------------!
+      !     Find the fraction of the canopy covered in snow (original snowfac function)    !
+      !     I think canopy roughness may need to be re-thought, but this was necessary     !
+      ! for turbulence & CO2 mixing to not occasionally fail sanity checks in young patches!
+      !------------------------------------------------------------------------------------!
+      snowfac_can     = min(9.9d-1,csite%total_sfcw_depth(ipa)/csite%veg_height(ipa))
+      !------------------------------------------------------------------------------------!
+
 
       !------------------------------------------------------------------------------------!
       !     If there is no vegetation in this patch, then we apply turbulence to bare      !
@@ -306,8 +315,8 @@ module canopy_struct_dynamics
          end if
 
          !----- Calculate the surface roughness inside the canopy. ------------------------!
-         csite%rough       (ipa) = soil_rough * (1.0 - csite%snowfac(ipa))                 &
-                                 + snow_rough * csite%snowfac(ipa)
+         csite%rough       (ipa) = soil_rough * (1.0 - snowfac_can)                 &
+                                 + snow_rough * snowfac_can
          csite%veg_displace(ipa) = vh2dh * csite%rough(ipa) / vh2vr
          !---------------------------------------------------------------------------------!
 
@@ -373,10 +382,10 @@ module canopy_struct_dynamics
          ! ground, and apply the snow cover to further scale it.  The weighting factors    !
          ! are the fraction of open canopy and the fraction of the canopy buried in snow.  !
          !---------------------------------------------------------------------------------!
-         csite%rough(ipa) = snow_rough * csite%snowfac(ipa)                                &
+         csite%rough(ipa) = snow_rough * snowfac_can		                               &
                           + ( soil_rough           * csite%opencan_frac(ipa)               &
                             + csite%veg_rough(ipa) * (1.0 - csite%opencan_frac(ipa)) )     &
-                          * (1.0 - csite%snowfac(ipa))
+                          * (1.0 - snowfac_can)
          !---------------------------------------------------------------------------------!
 
 
@@ -408,7 +417,7 @@ module canopy_struct_dynamics
          !---------------------------------------------------------------------------------!
          !     Find the aerodynamic resistance due to vegetated ground.                    !
          !---------------------------------------------------------------------------------!
-         if (csite%snowfac(ipa) < 0.9) then
+         if (snowfac_can < 0.9) then
             select case (icanturb)
             case (0)
                !----- LEAF-3 method. ------------------------------------------------------!
@@ -547,7 +556,7 @@ module canopy_struct_dynamics
          ! net resistance, which is, in turn, the weighted average of the resistances in   !
          ! bare and vegetated grounds.                                                     !
          !---------------------------------------------------------------------------------!
-         if (csite%opencan_frac(ipa) > 0.999 .or. csite%snowfac(ipa) >= 0.9) then
+         if (csite%opencan_frac(ipa) > 0.999 .or. snowfac_can >= 0.9) then
             csite%ggnet(ipa) = csite%ggbare(ipa)
          else
             csite%ggnet(ipa) = csite%ggbare(ipa) * csite%ggveg(ipa)                        &
@@ -572,17 +581,17 @@ module canopy_struct_dynamics
          ! soil and vegetation roughness.  The other is the fraction of the vegetation     !
          ! that is covered in snow.                                                        !
          !---------------------------------------------------------------------------------!
-         csite%rough(ipa) = snow_rough * csite%snowfac(ipa)                                &
+         csite%rough(ipa) = snow_rough * snowfac_can		                               &
                           + ( soil_rough           * csite%opencan_frac(ipa)               &
                             + csite%veg_rough(ipa) * (1.0 - csite%opencan_frac(ipa)) )     &
-                          * (1.0 - csite%snowfac(ipa))
+                          * (1.0 - snowfac_can)
          !---------------------------------------------------------------------------------!
 
 
 
          !----- Calculate the soil surface roughness inside the canopy. -------------------!
-         surf_rough = soil_rough * (1.0 - csite%snowfac(ipa))                              &
-                    + snow_rough * csite%snowfac(ipa)
+         surf_rough = soil_rough * (1.0 - snowfac_can)                              	   &
+                    + snow_rough * snowfac_can
          !---------------------------------------------------------------------------------!
 
 
@@ -713,7 +722,7 @@ module canopy_struct_dynamics
          ! net resistance, which is, in turn, the weighted average of the resistances in   !
          ! bare and vegetated grounds.                                                     !
          !---------------------------------------------------------------------------------!
-         if (csite%opencan_frac(ipa) > 0.999 .or. csite%snowfac(ipa) >= 0.9) then
+         if (csite%opencan_frac(ipa) > 0.999 .or. snowfac_can >= 0.9) then
             csite%ggnet(ipa) = csite%ggbare(ipa)
          else
             csite%ggnet(ipa) = csite%ggbare(ipa) * csite%ggveg(ipa)                        &
@@ -1297,7 +1306,7 @@ module canopy_struct_dynamics
          ! net resistance, which is, in turn, the weighted average of the resistances in   !
          ! bare and vegetated grounds.                                                     !
          !---------------------------------------------------------------------------------!
-         if (csite%opencan_frac(ipa) > 0.999 .or. csite%snowfac(ipa) >= 0.9) then
+         if (csite%opencan_frac(ipa) > 0.999 .or. snowfac_can >= 0.9) then
             csite%ggnet(ipa) = csite%ggbare(ipa)
          else
             csite%ggnet(ipa) = csite%ggbare(ipa) * csite%ggveg(ipa)                        &
@@ -1549,6 +1558,7 @@ module canopy_struct_dynamics
       logical        :: dry_grasses  ! Flag to check whether LAI+WAI is zero    [      ---]
       real(kind=8)   :: tai_drygrass ! TAI for when a grass-only patch is dry   [    m2/m2]
       real(kind=8)   :: c3_lad       ! c3 * lad for estimating drag coefficient [      ---]
+      real(kind=8)   :: snowfac_can  ! percent vertical canopy covered in snow
       !------ External procedures ---------------------------------------------------------!
       real(kind=8), external :: cbrt8    ! Cubic root that works for negative numbers
       real(kind=4), external :: sngloff  ! Safe double -> simple precision.
@@ -1560,6 +1570,13 @@ module canopy_struct_dynamics
       cpatch=>csite%patch(ipa)
       !------------------------------------------------------------------------------------!
 
+      !------------------------------------------------------------------------------------!
+      !     Find the fraction of the canopy covered in snow (original snowfac function)    !
+      !     I think canopy roughness may need to be re-thought, but this was necessary     !
+      ! for turbulence & CO2 mixing to not occasionally fail sanity checks in young patches!
+      !------------------------------------------------------------------------------------!
+      snowfac_can     = min(9.9d-1,initp%total_sfcw_depth/initp%veg_height)
+      !------------------------------------------------------------------------------------!
 
       !------------------------------------------------------------------------------------!
       !     Find the virtual potential temperatures and decide whether the canopy air is   !
@@ -1576,8 +1593,8 @@ module canopy_struct_dynamics
       if (cpatch%ncohorts == 0) then
 
          !----- Calculate the surface roughness and displacement height. ------------------!
-         initp%rough        = soil_rough8 *(1.d0 - initp%snowfac)                          &
-                            + snow_rough8 * initp%snowfac
+         initp%rough        = soil_rough8 *(1.d0 - snowfac_can)                            &
+                            + snow_rough8 * snowfac_can
          initp%veg_displace = vh2dh8 * initp%rough / vh2vr8
          
          !----- Find the characteristic scales (a.k.a. stars). ----------------------------!
@@ -1639,10 +1656,10 @@ module canopy_struct_dynamics
          ! soil and vegetation roughness.  The other is the fraction of the vegetation     !
          ! that is covered in snow.                                                        !
          !---------------------------------------------------------------------------------!
-         initp%rough = snow_rough8 * initp%snowfac                                         &
+         initp%rough = snow_rough8 * snowfac_can                                           &
                      + ( soil_rough8     * initp%opencan_frac                              &
                        + initp%veg_rough * (1.d0 - initp%opencan_frac) )                   &
-                     * (1.d0 - initp%snowfac)
+                     * (1.d0 - snowfac_can)
          !---------------------------------------------------------------------------------!
 
 
@@ -1662,7 +1679,7 @@ module canopy_struct_dynamics
          !---------------------------------------------------------------------------------!
          !     Find the aerodynamic resistance due to vegetated ground.                    !
          !---------------------------------------------------------------------------------!
-         if (initp%snowfac < 9.d-1) then
+         if (snowfac_can < 9.d-1) then
             select case (icanturb)
             case (0)
                !----- LEAF-3 method. ------------------------------------------------------!
@@ -1814,7 +1831,7 @@ module canopy_struct_dynamics
          ! net resistance, which is, in turn, the weighted average of the resistances in   !
          ! bare and vegetated grounds.                                                     !
          !---------------------------------------------------------------------------------!
-         if (initp%opencan_frac > 9.99d-1 .or. initp%snowfac >= 9.d-1) then
+         if (initp%opencan_frac > 9.99d-1 .or. snowfac_can >= 9.d-1) then
             initp%ggnet = initp%ggbare
          else
             initp%ggnet = initp%ggbare * initp%ggveg                                       &
@@ -1838,14 +1855,14 @@ module canopy_struct_dynamics
          ! soil and vegetation roughness.  The other is the fraction of the vegetation     !
          ! that is covered in snow.                                                        !
          !---------------------------------------------------------------------------------!
-         initp%rough = snow_rough8 * initp%snowfac                                         &
+         initp%rough = snow_rough8 * snowfac_can                                           &
                      + ( soil_rough8     * initp%opencan_frac                              &
                        + initp%veg_rough * (1.d0 - initp%opencan_frac) )                   &
-                     * (1.d0 - initp%snowfac)
+                     * (1.d0 - snowfac_can)
          !---------------------------------------------------------------------------------!
          
          !----- Calculate the soil surface roughness inside the canopy. -------------------!
-         surf_rough = soil_rough8 * (1.d0 - initp%snowfac) + snow_rough8 * initp%snowfac
+         surf_rough = soil_rough8 * (1.d0 - snowfac_can) + snow_rough8 * snowfac_can
          !---------------------------------------------------------------------------------!
 
 
@@ -1979,7 +1996,7 @@ module canopy_struct_dynamics
          ! net resistance, which is, in turn, the weighted average of the resistances in   !
          ! bare and vegetated grounds.                                                     !
          !---------------------------------------------------------------------------------!
-         if (initp%opencan_frac > 9.99d-1 .or. initp%snowfac >= 9.d-1) then
+         if (initp%opencan_frac > 9.99d-1 .or. snowfac_can >= 9.d-1) then
             initp%ggnet = initp%ggbare
          else
             initp%ggnet = initp%ggbare * initp%ggveg                                       &
@@ -2561,7 +2578,7 @@ module canopy_struct_dynamics
          ! net resistance, which is, in turn, the weighted average of the resistances in   !
          ! bare and vegetated grounds.                                                     !
          !---------------------------------------------------------------------------------!
-         if (initp%opencan_frac > 9.99d-1 .or. initp%snowfac >= 9.d-1) then
+         if (initp%opencan_frac > 9.99d-1 .or. snowfac_can >= 9.d-1) then
             initp%ggnet = initp%ggbare
          else
             initp%ggnet = initp%ggbare * initp%ggveg                                       &

--- a/ED/src/dynamics/rk4_derivs.F90
+++ b/ED/src/dynamics/rk4_derivs.F90
@@ -484,7 +484,8 @@ subroutine leaftw_derivs(mzg,mzs,initp,dinitp,csite,ipa,dt,is_hybrid)
       avg_th_cond               =  rk4aux%th_cond_s(mzg)                                   &
                                 *  ( rk4aux%th_cond_p(1) / rk4aux%th_cond_s(mzg) )         &
                                 ** ( dslz8(mzg) / (initp%sfcwater_depth(1)+ dslz8(mzg)))  
-      rk4aux%h_flux_g   (mzg+1) = - avg_th_cond * initp%snowfac                            &
+!      rk4aux%h_flux_g   (mzg+1) = - avg_th_cond * initp%snowfac                            &
+      rk4aux%h_flux_g   (mzg+1) = - avg_th_cond				                               &
                                 * (initp%sfcwater_tempk(1) - initp%soil_tempk(mzg))        &
                                 / (5.d-1 * initp%sfcwater_depth(1) - slzt8(mzg) )         
       rk4aux%h_flux_s   (1)     = rk4aux%h_flux_g(mzg+1)                               
@@ -510,7 +511,8 @@ subroutine leaftw_derivs(mzg,mzs,initp,dinitp,csite,ipa,dt,is_hybrid)
                                   - dble(csite%rshort_g(ipa))
    rk4aux%h_flux_g        (mzg+1) = rk4aux%h_flux_g(mzg+1) + dinitp%avg_sensible_gg (mzg)
    !---------------------------------------------------------------------------------------!
-
+   rk4aux%h_flux_s        (mzs+1) = rk4aux%h_flux_s(mzs+1) + hflxsc + qwflxsc - 		   &
+   									dble(csite%rlong_s(ipa)) - dble(csite%rshort_s(mzs,ipa))
 
 
 
@@ -1003,6 +1005,13 @@ subroutine canopy_derivs_two(mzg,initp,dinitp,csite,ipa,hflxsc,wflxsc,qwflxsc,hf
    closedcan_frac = max(0.d0,min(1.d0,1.d0-initp%opencan_frac))
    !---------------------------------------------------------------------------------------!
 
+
+   !---------------------------------------------------------------------------------------!
+   !     Set all heat fluxes to zero, we only add them if they occur and are allowed.      !
+   !---------------------------------------------------------------------------------------!
+   hflxsc         = 0.d0
+   hflxgc         = 0.d0
+   !---------------------------------------------------------------------------------------!
 
 
    !---------------------------------------------------------------------------------------!

--- a/ED/src/dynamics/rk4_misc.f90
+++ b/ED/src/dynamics/rk4_misc.f90
@@ -1294,7 +1294,8 @@ subroutine adjust_sfcw_properties(nzg,nzs,initp,hdid,csite,ipa)
                             , wdnsi8                & ! intent(in)
                             , uiliqt38              & ! intent(in)
                             , wdnsi8                & ! intent(in)
-                            , fdnsi8                ! ! intent(in)
+                            , fdnsi8                & ! intent(in)
+                            , fsdnsi8               ! ! intent(in)
    use therm_lib8    , only : uint2tl8              & ! subroutine
                             , uextcm2tl8            & ! subroutine
                             , tl2uint8              & ! function
@@ -2015,8 +2016,11 @@ subroutine adjust_sfcw_properties(nzg,nzs,initp,hdid,csite,ipa)
          !     Check whether the layer as is meet the minimum requirements to stand as a   !
          ! new layer by itself.                                                            !
          !---------------------------------------------------------------------------------!
-         if ( initp%sfcwater_mass(k)   >  rk4tiny_sfcw_mass              .and.             &
-              rk4snowmin * thicknet(k) <= sum_sfcw_mass                  .and.             &
+!         if ( initp%sfcwater_mass(k)   >  rk4tiny_sfcw_mass              .and.             &
+!              rk4snowmin * thicknet(k) <= sum_sfcw_mass                  .and.             &
+!              initp%sfcwater_energy(k) <  initp%sfcwater_mass(k)*uiliqt38      ) then
+         if ( initp%sfcwater_mass(k)   >=  rk4snowmin		             .and.             &
+              rk4snowmin * fsdnsi8 <= initp%sfcwater_depth(k)            .and.             &
               initp%sfcwater_energy(k) <  initp%sfcwater_mass(k)*uiliqt38      ) then
             newlayers = newlayers + 1
          end if

--- a/ED/src/init/ed_init.f90
+++ b/ED/src/init/ed_init.f90
@@ -625,7 +625,7 @@ subroutine sfcdata_ed()
          thicknet(kzs)      = thicknet(kzs) + 2. * thik
          thik               = thik * stretch
       end do
-      if ((kzs+1)/2 .ne. kzs/2) thicknet(kzs) = thicknet(kzs) - thik/stretch
+      if (MOD(kzs, 2) .ne. 0) thicknet(kzs) = thicknet(kzs) - thik/stretch
       do k = 1,kzs
          thick(k,kzs) = thick(k,kzs) / thicknet(kzs)
       end do

--- a/ED/src/utils/ed_therm_lib.f90
+++ b/ED/src/utils/ed_therm_lib.f90
@@ -162,7 +162,7 @@ module ed_therm_lib
          else
             !----- Find the snow layer that is the closest to where the leaves would be. --!
             do k = csite%nlev_sfcwater(ipa), 1, -1
-               if (sum(csite%sfcwater_depth(1:k,ipa)) > cpatch%hite(ico)) then
+               if (sum(csite%sfcwater_depth(1:k,ipa)) >= cpatch%hite(ico)) then
                   kclosest = k
                end if
             end do


### PR DESCRIPTION
A number of small fixes regarding snow and temporary water in ED.  Tweaks center around 2 themes:
1. Rules regarding snow layers.  This includes rules for creating new layers and how top/bottom snow layers interact with the ground & air
2. The snowfac usage in canopy_struct_dynamics.  The most recent changes to snowfac would cause problems with CO2 going out of bounds in certain cases.  This should probably be looked into in greater depth in the future.


Specific Edits & Rationale:

Canopy_struct_dynamics:
Re-implemented old version of snowfac (percentage of vertical canopy
covered by snow). Old version was causing CO2 to go out of bounds in
young patches due to weird canopy roughness

rk4_derivs:
line 487: this should not be scaled by snowfac.  We need to relative
fluxes and this is not affected by how much of the area is covered in
snow.
line 514: the top layer of snow needs to interact with the air to
prevent massive amounts of energy transfer back & forth between snow
layers (which causes the spiral out of control)
1009-1014: we may not need this

rk4_misc:
changed the rules for creating a new snow layer so that minimum mass,
depth & energy conditions must be met.  This prevents the formation of
layers with 1/2 of the total mass, but only a small fraction of the
energy (which makes a very cold layer & contributed to the spiral out
of control)

ed_init:
corrected thickness allocation, so that it evaluates FALSE for even
numbers (old version could never be false)

ed_therm_lib
fix bug that caused a crash when sfcwater_depth = plant height