### PR TITLE
allocate longer filename vars in libxml2f90

### DIFF
--- a/ED/src/utils/libxml2f90.f90_pp.f90
+++ b/ED/src/utils/libxml2f90.f90_pp.f90
@@ -44,7 +44,7 @@ module libxml2f90_module
   character(1),allocatable    ::  tempstringa(:)
   integer(4)                  ::  filelines
   integer(4)                  ::  lbact
-  character(32)               ::  default_llid='CNTL'
+  character(1024)               ::  default_llid='CNTL'
   integer(4)                  ::  xmlformat=3
   integer(4)                  ::  arraystep=2000
   integer(4)                  ::  indstep=2
@@ -430,7 +430,7 @@ end module libxml2f90_strings_module
 
 module ll_module
   type ll_type
-     character(32)            :: LL_ID
+     character(1024)            :: LL_ID
      character(32)            :: TAG
      character(32)            :: ID
      character(1),dimension(:),pointer :: VALUE


### PR DESCRIPTION
Previoulsy, ED would crash if run with config.xml files whose path+filename was >32 characters. Limit now increased to 1024 characters. 