### PR TITLE
Fix short-circuit logic in fuse_fiss_utils

### DIFF
--- a/ED/src/utils/fuse_fiss_utils.f90
+++ b/ED/src/utils/fuse_fiss_utils.f90
@@ -4679,7 +4679,8 @@ module fuse_fiss_utils
       !------------------------------------------------------------------------------------! 
       !    Daily means.                                                                    !
       !------------------------------------------------------------------------------------! 
-      if (writing_long .and. all(csite%dmean_can_prss > 10.0) ) then
+      if (writing_long) then
+        if ( all(csite%dmean_can_prss > 10.0) ) then
 
          csite%dmean_A_decomp           (recp) = ( csite%dmean_A_decomp           (recp)   &
                                                  * csite%area                     (recp)   &
@@ -5002,14 +5003,15 @@ module fuse_fiss_utils
             csite%dmean_sfcw_fliq  (recp)  = csite%dmean_soil_fliq(mzg,recp)
          end if
          !------------------------------------------------------------------------------------!
-
+        end if
       end if
       !------------------------------------------------------------------------------------!
 
       !------------------------------------------------------------------------------------! 
       !    Monthly means.                                                                  !
       !------------------------------------------------------------------------------------! 
-      if (writing_eorq .and. all(csite%mmean_can_prss > 10.0) ) then
+      if (writing_eorq) then
+        if( all(csite%mmean_can_prss > 10.0) ) then
 
          !---------------------------------------------------------------------------------!
          !    First we find the mean sum of squares, because they depend on the means too, !
@@ -5483,6 +5485,7 @@ module fuse_fiss_utils
             csite%mmean_sfcw_fliq  (recp)  = csite%mmean_soil_fliq(mzg,recp)
          end if
          !------------------------------------------------------------------------------------!
+        end if
       end if
       !------------------------------------------------------------------------------------!
 
@@ -5492,7 +5495,8 @@ module fuse_fiss_utils
       !------------------------------------------------------------------------------------! 
       !    Mean diel.                                                                      !
       !------------------------------------------------------------------------------------! 
-      if (writing_dcyc .and. all(csite%qmean_can_prss > 10.0)) then
+      if (writing_dcyc) then
+        if( all(csite%qmean_can_prss > 10.0) ) then
 
          !---------------------------------------------------------------------------------!
          !      First we solve the mean sum of squares as they depend on the mean and the  !
@@ -5913,6 +5917,7 @@ module fuse_fiss_utils
             !------------------------------------------------------------------------------!
          end do
          !---------------------------------------------------------------------------------!
+        end if
       end if
       !------------------------------------------------------------------------------------!
 


### PR DESCRIPTION
In fuse_2_patches, the code evaluates:

`writing_long .and. all(csite%dmean_can_prss > 10.0)`

`csite%dmean_can_prss` will not be allocated unless writing_long is true,
so if writing_long is false and the second expression is evaluated, a segfault
results.

Apparently, different compilers handle these compound logic statements
in different ways. I assume that for many folks the logic is short-circuited
so that whenever writing_long is false the all(...) expression is never
evaluated, because otherwise this probably would have come up before.

I always get the segfault, however. Changing the code to explicitly check
the first expression before moving on to the second fixed it for me and shouldn't
affect anyone who had it working already.

(There are two other analogous `if()` statements that were changed the same way.)