### PR TITLE
Initialize par_level variables for SMP

### DIFF
--- a/ED/src/init/ed_type_init.f90
+++ b/ED/src/init/ed_type_init.f90
@@ -145,9 +145,9 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
    cpatch%light_level_beam      (ico) = 0.0
    cpatch%light_level_diff      (ico) = 0.0
 
-   cpatch%par_level_beam       (ico) = 0.0
-   cpatch%par_level_diffu      (ico) = 0.0
-   cpatch%par_level_diffd      (ico) = 0.0
+   cpatch%par_level_beam        (ico) = 0.0
+   cpatch%par_level_diffu       (ico) = 0.0
+   cpatch%par_level_diffd       (ico) = 0.0
 
    cpatch%gpp                   (ico) = 0.0
    cpatch%leaf_respiration      (ico) = 0.0
@@ -254,6 +254,11 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
    cpatch%fmean_light_level       (ico) = 0.0
    cpatch%fmean_light_level_beam  (ico) = 0.0
    cpatch%fmean_light_level_diff  (ico) = 0.0
+
+   cpatch%fmean_par_level_beam    (ico) = 0.0
+   cpatch%fmean_par_level_diffu   (ico) = 0.0
+   cpatch%fmean_par_level_diffd   (ico) = 0.0
+
    cpatch%fmean_par_l             (ico) = 0.0
    cpatch%fmean_par_l_beam        (ico) = 0.0
    cpatch%fmean_par_l_diff        (ico) = 0.0
@@ -318,6 +323,11 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
       cpatch%dmean_light_level       (ico) = 0.0
       cpatch%dmean_light_level_beam  (ico) = 0.0
       cpatch%dmean_light_level_diff  (ico) = 0.0
+
+      cpatch%dmean_par_level_beam    (ico) = 0.0
+      cpatch%dmean_par_level_diffu   (ico) = 0.0
+      cpatch%dmean_par_level_diffd   (ico) = 0.0
+
       cpatch%dmean_par_l             (ico) = 0.0
       cpatch%dmean_par_l_beam        (ico) = 0.0
       cpatch%dmean_par_l_diff        (ico) = 0.0
@@ -375,6 +385,11 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
       cpatch%mmean_light_level         (ico) = 0.0
       cpatch%mmean_light_level_beam    (ico) = 0.0
       cpatch%mmean_light_level_diff    (ico) = 0.0
+
+      cpatch%mmean_par_level_beam      (ico) = 0.0
+      cpatch%mmean_par_level_diffu     (ico) = 0.0
+      cpatch%mmean_par_level_diffd     (ico) = 0.0
+
       cpatch%mmean_par_l               (ico) = 0.0
       cpatch%mmean_par_l_beam          (ico) = 0.0
       cpatch%mmean_par_l_diff          (ico) = 0.0
@@ -457,6 +472,11 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
       cpatch%qmean_light_level       (:,ico) = 0.0
       cpatch%qmean_light_level_beam  (:,ico) = 0.0
       cpatch%qmean_light_level_diff  (:,ico) = 0.0
+
+      cpatch%qmean_par_level_beam    (:,ico) = 0.0
+      cpatch%qmean_par_level_diffu   (:,ico) = 0.0
+      cpatch%qmean_par_level_diffd   (:,ico) = 0.0
+
       cpatch%qmean_par_l             (:,ico) = 0.0
       cpatch%qmean_par_l_beam        (:,ico) = 0.0
       cpatch%qmean_par_l_diff        (:,ico) = 0.0


### PR DESCRIPTION
par_level variables were missing causing random SIGFPE errors.  This pull request adds them.