### PR TITLE
generate_deps.sh update for Mac + NetCDF libraries update

### DIFF
--- a/RAPP/build/bin/generate_deps.sh
+++ b/RAPP/build/bin/generate_deps.sh
@@ -4,6 +4,7 @@ includes="-I ${rapproot}/src/include"
 rappsrc="${rapproot}/src/*/*.f90 ${rapproot}/src/*/*.F90 ${rapproot}/src/*/*.c"
 /bin/rm -f dependency.mk
 ./sfmakedepend.pl ${includes} -f dependency.mk ${rappsrc}
-sed -i s@hdf5.mod@@g dependency.mk
-sed -i s@netcdf.mod@@g dependency.mk
+sed -i .old s@hdf5.mod@@g dependency.mk
+sed -i .old 's@[^_]netcdf.mod@ @g' dependency.mk
 /bin/rm -f dependency.alt dependency.mk.old*
+

--- a/RAPP/build/bin/include.mk.macosx
+++ b/RAPP/build/bin/include.mk.macosx
@@ -26,7 +26,7 @@ HDF5_LIBS=-lm -lz -L/sw/hdf5/lib -lhdf5 -lhdf5_fortran
 #------------------------------------------------------------------------------------------#
 USE_NCDF=1
 NCDF_INCS=-I/sw/include
-NCDF_LIBS=-L/sw/lib -lnetcdf
+NCDF_LIBS=-L/usr/local/lib -lnetcdff -lnetcdf
 
 #------ Defining the compiler and library paths in case they are not in LD_LIBRARY_PATH ---#
 CMACH=MAC_OS_X


### PR DESCRIPTION
The “sed” command in generate_deps.sh fails on Unix, it expects an
extension as an argument. Also changed wording so it does not remove
netcdf.mod from mod_netcdf.mod in dependency.mk.
Changes in the include.mk template are for if you’re using the latest
NetCDF install (separate C and Fortran installations, I have NetCDF
4.3.3.1 for C and NetCDF 4.4.2 for Fortran)