### PR TITLE
update RAPP to process NCEP reanalysis .nc files which are now float type

### DIFF
--- a/RAPP/src/interp/space_interp.f90
+++ b/RAPP/src/interp/space_interp.f90
@@ -534,7 +534,11 @@ subroutine oa_2ndpass(mtp,vname,lonlola,latlola,vlola,longauss,latgauss,vgauss)
             !      expected value, and it is simply the difference between the expected    !
             !      and the estimated values.                                               ! 
             !------------------------------------------------------------------------------!
-            interp_buffer%residu(xl,yl,tt) = vlola(xl,yl,tt) - vest
+            if (vlola(xl,yl,tt) == missflg_real) then
+               interp_buffer%residu(xl,yl,tt) = missflg_real
+            else
+               interp_buffer%residu(xl,yl,tt) = vlola(xl,yl,tt) - vest
+            end if
          end do rtloop
 
       end do rxloop
@@ -632,6 +636,7 @@ end subroutine oa_2ndpass
 ! we do not want to include.                                                               !
 !------------------------------------------------------------------------------------------!
 real function wei_ave(mxp,myp,xa,xz,ya,yz,var,weight,mask)
+    use mod_ioopts , only : missflg_real  ! ! intent(in)
    implicit none
    !----- Arguments. ----------------------------------------------------------------------!
    integer                    , intent(in) :: mxp
@@ -659,7 +664,7 @@ real function wei_ave(mxp,myp,xa,xz,ya,yz,var,weight,mask)
    yloop: do y=ya,yz
       xloop: do x=xa,xz
          !----- Skip this point if it has a tiny influence on the total weight. -----------!
-         if (.not. mask(x,y)) cycle xloop
+         if ((.not. mask(x,y)) .or. var(x,y) == missflg_real) cycle xloop
 
          wsum  = wsum  + weight(x,y)
          fwsum = fwsum + weight(x,y) * var(x,y)

--- a/RAPP/src/modules/mod_ioopts.f90
+++ b/RAPP/src/modules/mod_ioopts.f90
@@ -52,9 +52,9 @@ module mod_ioopts
    !----- Parameters ----------------------------------------------------------------------!
    integer               , parameter           :: nvars = 11 ! # of variables
    integer               , parameter           :: missflg_int   = 999999
-   real                  , parameter           :: missflg_real  = 1.E+34 
+   real                  , parameter           :: missflg_real  = -9.9692100E+36 !1.E+34
    character(len=maxstr) , parameter           :: missflg_char  = '___'
-   real(kind=8)          , parameter           :: missflg_dble  = 1.D+34 
+   real(kind=8)          , parameter           :: missflg_dble  = -9.96920996838687e+36 -9.96921E36 !1.D+34 
    integer               , parameter           :: rapp_absent   = -999
    integer               , parameter           :: rapp_badtype  = -888
    integer               , parameter           :: rapp_partly   = -777

--- a/RAPP/src/modules/mod_ncdf_globio.F90
+++ b/RAPP/src/modules/mod_ncdf_globio.F90
@@ -433,7 +433,7 @@ module mod_ncdf_globio
       character(len=15), external         :: grads_dtstamp
       character(len=17), external         :: rapp_dtstamp
       !----- Local variables --------------------------------------------------------------!
-      integer     , dimension(ntimes)          :: tmpvar
+      real(kind=4)     , dimension(ntimes)          :: tmpvar
       real(kind=8), dimension(ntimes)          :: tdble
       integer                                  :: ierr
       integer                                  :: t
@@ -1282,7 +1282,7 @@ module mod_ncdf_globio
       !----- Optional output, only one of them should appear there ------------------------!
       real, dimension(dim1,dim2), intent(out) :: realout
       !----- Local variables --------------------------------------------------------------!
-      integer(kind=2), dimension(dim1,dim2)   :: tmpvar
+      real(kind=4), dimension(dim1,dim2)   :: tmpvar
       integer                                 :: ierr,off1,off2,str1,str2
       integer, dimension(3)                   :: start,count,stride
       integer(kind=2)                         :: missshort
@@ -1330,8 +1330,8 @@ module mod_ncdf_globio
             call ncdf_load_err(ierr)
             call  fatal_error('Failed retrieving dimension '//trim(varname)//'!!!'         &
                              ,'ncio_2dshort','mod_ncdf_globio.F90')
-         elseif (xtype /= NF90_SHORT) then
-            call fatal_error('Variable '//trim(varname)//' is not short integer!'          &
+         elseif (xtype /= NF90_FLOAT) then
+            call fatal_error('Variable '//trim(varname)//' is not float!'          &
                             ,'ncio_2dshort','mod_ncdf_globio.F90')
          elseif (ndims /= 3) then !--- 3 dimensions because one is time... ----------------!
             call fatal_error('ncio_2dshort downloads only 2D variables and '//             &
@@ -1351,7 +1351,9 @@ module mod_ncdf_globio
             ierr = nf90_get_att(ncid,varid,'missing_value',missshort)
             ierr = nf90_get_att(ncid,varid,'add_offset'   ,refval   )
             ierr = nf90_get_att(ncid,varid,'scale_factor' ,scalefac )
-            
+            scalefac = 1
+            refval = 0
+
             !----- Converting the values to the real form ---------------------------------!
             where (tmpvar /= missshort)
                realout = refval + scalefac*real(tmpvar)
@@ -1396,7 +1398,7 @@ module mod_ncdf_globio
       !----- Optional output, only one of them should appear there ------------------------!
       real, dimension(dim1,dim2,dim3), intent(out) :: realout
       !----- Local variables --------------------------------------------------------------!
-      integer(kind=2), dimension(dim1,dim2,dim3)   :: tmpvar
+      real(kind=4), dimension(dim1,dim2,dim3)   :: tmpvar
       integer                                      :: ierr,off1,off2,off3,str1,str2,str3
       integer, dimension(4)                        :: start,count,stride
       integer(kind=2)                              :: missshort
@@ -1446,8 +1448,8 @@ module mod_ncdf_globio
             call ncdf_load_err(ierr)
             call  fatal_error('Failed retrieving dimension '//trim(varname)//'!!!'         &
                              ,'ncio_3dshort','mod_ncdf_globio.F90')
-         elseif (xtype /= NF90_SHORT) then
-            call fatal_error('Variable '//trim(varname)//' is not short integer!'          &
+         elseif (xtype /= NF90_FLOAT) then
+            call fatal_error('Variable '//trim(varname)//' is not float!'          &
                             ,'ncio_3dshort','mod_ncdf_globio.F90')
          elseif (ndims /= 4) then !--- 4 dimensions because one is time... ----------------!
             call fatal_error('ncio_3dshort downloads only 3D variables and '//             &
@@ -1467,7 +1469,8 @@ module mod_ncdf_globio
             ierr = nf90_get_att(ncid,varid,'missing_value',missshort)
             ierr = nf90_get_att(ncid,varid,'add_offset'   ,refval   )
             ierr = nf90_get_att(ncid,varid,'scale_factor' ,scalefac )
-            
+            scalefac = 1
+            refval = 0
             !----- Converting the values to the real form ---------------------------------!
             where (tmpvar /= missshort)
                realout = refval + scalefac*real(tmpvar)

--- a/RAPP/src/ncep/ncep_fill_infotable.F90
+++ b/RAPP/src/ncep/ncep_fill_infotable.F90
@@ -344,7 +344,7 @@ subroutine ncep_load_var_table(nv,current_grid,varname,npointer,idim_type,ngrid,
       end if
 
    !----- Real, scalar, vectors and higher-rank arrays are considered, check everything ---!
-   elseif (xtype == NF90_SHORT) then
+   elseif (xtype == NF90_FLOAT) then
       select case(ndims)
 
       !------------------------------------------------------------------------------------!

--- a/RAPP/src/ncep/ncep_loadvars.F90
+++ b/RAPP/src/ncep/ncep_loadvars.F90
@@ -105,6 +105,10 @@ logical function ncep_loadvars()
          call loadshort(info_table(nv)%filename,vars_ncep(nv),ssxp(ifm),ssyp(ifm)          &
                        ,sstp(ifm),x_1st(ifm),y_1st(ifm),t_1st(ifm),tlast(ifm)              &
                        ,ncep_g(ifm)%prate,ierr)
+        !this is the code that I added from marcos to cut missing values
+         where (ncep_g(ifm)%prate == missflg_real)
+            ncep_g(ifm)%prate = 0.
+         end where
 
       end select
    end do varloop
@@ -215,7 +219,7 @@ subroutine loadshort(filename,varname,mxp,myp,mtp,xa,ya,ta,tz,var,ierr)
    !----- Loop over times and load the variable into the array. ---------------------------!
    do tabs=ta,tz
       tloc = tabs - ta + 1
-      ierr = ncio_2dshort(varname,.true.,tabs,mxp,myp,var(:,:,tloc)                        &
+      ierr = ncio_2dvar(varname,.true.,tabs,mxp,myp,var(:,:,tloc)                        &
                          ,offin1=xoff,offin2=yoff)
    end do
 


### PR DESCRIPTION
Just a few simple changes to make the RAPP code work with the NCEP reanalysis netcdf files that were integers before but are now 32-bit float, also the new files don't have scaling factor and add offset which were set to 1 and 0 respectively. I have also updated the missing flag value. Code has been tested and it works.
Thanks also to @mpaiao 