### PR TITLE
Bug fixes for adding radiative equations from ed_params to radiative_…

### DIFF
--- a/ED/src/dynamics/radiate_driver.f90
+++ b/ED/src/dynamics/radiate_driver.f90
@@ -342,32 +342,6 @@
     real(kind=8)    , parameter                   :: tiny_offset = 1.d-20
     !---------------------------------------------------------------------------------------!
 
-    !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(         &
-    !$OMP ibuff,cpatch,cohort_count,tuco,tuco_leaf,    &
-    !$OMP ico,bl_lai_each,bl_wai_each,nsoil,colour,    &
-    !$OMP albedo_soil_par,albedo_soil_nir,             &
-    !$OMP albedo_damp_par,albedo_damp_nir,fcpct,       &
-    !$OMP rad_sfcw_par,rad_sfcw_nir,albedo_ground_par, &
-    !$OMP albedo_ground_nir,abs_sfcw_par,abs_sfcw_nir, &
-    !$OMP emissivity,T_surface,ksn,albedo_sfcw_par,    &
-    !$OMP albedo_sfcw_nir,k,sfcw_odepth,fractrans_par, &
-    !$OMP fractrans_nir,downward_lw_below,             &
-    !$OMP upward_lw_below,upward_lw_above,             &
-    !$OMP surface_netabs_longwave,                     &
-    !$OMP downward_par_below_beam,                     &
-    !$OMP downward_par_below_diffuse,                  &
-    !$OMP upward_par_above_diffuse,                    &
-    !$OMP downward_nir_below_beam,                     &
-    !$OMP downward_nir_below_diffuse,                  &
-    !$OMP upward_nir_above_diffuse,                    &
-    !$OMP ipft,wleaf_vis,wleaf_nir,wleaf_tir,          &
-    !$OMP wwood_vis,wwood_nir,wwood_tir,               &
-    !$OMP upward_rshort_above_diffuse,                 &
-    !$OMP downward_rshort_below_beam,                  &
-    !$OMP downward_rshort_below_diffuse,               &
-    !$OMP il,nir_v_beam,nir_v_diffuse,                 &
-    !$OMP abs_ground_par,abs_ground_nir )                
-
    !---------------------------------------------------------------------------------------!
    !     Scattering coefficients.  Contrary to ED-2.1, these values are based on the       !
    ! description by by Sellers (1985) and the CLM technical manual, which includes the     !
@@ -436,6 +410,34 @@
        end if
     end do
    !---------------------------------------------------------------------------------------!
+
+
+    !$OMP PARALLEL DO DEFAULT(SHARED) PRIVATE(         &
+    !$OMP ibuff,cpatch,cohort_count,tuco,tuco_leaf,    &
+    !$OMP ico,bl_lai_each,bl_wai_each,nsoil,colour,    &
+    !$OMP albedo_soil_par,albedo_soil_nir,             &
+    !$OMP albedo_damp_par,albedo_damp_nir,fcpct,       &
+    !$OMP rad_sfcw_par,rad_sfcw_nir,albedo_ground_par, &
+    !$OMP albedo_ground_nir,abs_sfcw_par,abs_sfcw_nir, &
+    !$OMP emissivity,T_surface,ksn,albedo_sfcw_par,    &
+    !$OMP albedo_sfcw_nir,k,sfcw_odepth,fractrans_par, &
+    !$OMP fractrans_nir,downward_lw_below,             &
+    !$OMP upward_lw_below,upward_lw_above,             &
+    !$OMP surface_netabs_longwave,                     &
+    !$OMP downward_par_below_beam,                     &
+    !$OMP downward_par_below_diffuse,                  &
+    !$OMP upward_par_above_diffuse,                    &
+    !$OMP downward_nir_below_beam,                     &
+    !$OMP downward_nir_below_diffuse,                  &
+    !$OMP upward_nir_above_diffuse,                    &
+    !$OMP ipft,wleaf_vis,wleaf_nir,wleaf_tir,          &
+    !$OMP wwood_vis,wwood_nir,wwood_tir,               &
+    !$OMP upward_rshort_above_diffuse,                 &
+    !$OMP downward_rshort_below_beam,                  &
+    !$OMP downward_rshort_below_diffuse,               &
+    !$OMP il,nir_v_beam,nir_v_diffuse,                 &
+    !$OMP abs_ground_par,abs_ground_nir )                
+
     
     !----- Loop over the patches -----------------------------------------------------------!
     do ipa = 1,csite%npatches

--- a/ED/src/init/ed_params.f90
+++ b/ED/src/init/ed_params.f90
@@ -526,17 +526,14 @@ subroutine init_can_rad_params()
                                     , orient_grass                & ! intent(in)
                                     , clump_tree                  & ! intent(in)
                                     , clump_grass                 & ! intent(in)
-                                    , leaf_reflect_nir            & ! intent(out)
-                                    , leaf_trans_nir              & ! intent(out)
+                                    , leaf_reflect_nir            & ! intent(in)
+                                    , leaf_trans_nir              & ! intent(in)
                                     , leaf_scatter_nir            & ! intent(out)
-                                    , leaf_reflect_vis            & ! intent(out)
-                                    , leaf_trans_vis              & ! intent(out)
+                                    , leaf_reflect_vis            & ! intent(in)
+                                    , leaf_trans_vis              & ! intent(in)
                                     , leaf_scatter_vis            & ! intent(out)
-                                    , leaf_reflect_vis            & ! intent(out)
-                                    , leaf_trans_vis              & ! intent(out)
-                                    , leaf_scatter_tir            & ! intent(out)
-                                    , leaf_backscatter_vis        & ! intent(out)
-                                    , leaf_backscatter_nir        & ! intent(out)
+                                    , leaf_backscatter_vis        & ! intent(in)
+                                    , leaf_backscatter_nir        & ! intent(in)
                                     , leaf_backscatter_tir        & ! intent(out)
                                     , leaf_emiss_tir              & ! intent(out)
                                     , clumping_factor             & ! intent(out)
@@ -544,17 +541,17 @@ subroutine init_can_rad_params()
                                     , phi1                        & ! intent(out)
                                     , phi2                        & ! intent(out)
                                     , mu_bar                      & ! intent(out)
-                                    , wood_reflect_nir            & ! intent(out)
-                                    , wood_trans_nir              & ! intent(out)
+                                    , wood_reflect_nir            & ! intent(in)
+                                    , wood_trans_nir              & ! intent(in)
                                     , wood_scatter_nir            & ! intent(out)
-                                    , wood_reflect_vis            & ! intent(out)
-                                    , wood_trans_vis              & ! intent(out)
+                                    , wood_reflect_vis            & ! intent(in)
+                                    , wood_trans_vis              & ! intent(in)
                                     , wood_scatter_vis            & ! intent(out)
-                                    , wood_reflect_vis            & ! intent(out)
-                                    , wood_trans_vis              & ! intent(out)
+                                    , wood_reflect_vis            & ! intent(in)
+                                    , wood_trans_vis              & ! intent(in)
                                     , wood_scatter_tir            & ! intent(out)
-                                    , wood_backscatter_vis        & ! intent(out)
-                                    , wood_backscatter_nir        & ! intent(out)
+                                    , wood_backscatter_vis        & ! intent(in)
+                                    , wood_backscatter_nir        & ! intent(in)
                                     , wood_backscatter_tir        & ! intent(out)
                                     , wood_emiss_tir              & ! intent(out)
                                     , fvis_beam_def               & ! intent(out)
@@ -795,18 +792,6 @@ subroutine init_can_rad_params()
    ! when the leaf orientation is random.                                                  !
    !---------------------------------------------------------------------------------------!
    do ipft = 1, n_pft
-
-      !----- Near infrared (NIR). ---------------------------------------------------------!
-      leaf_backscatter_nir(ipft) = ( leaf_scatter_nir(ipft)                                &
-                                   + 2.5d-1                                                &
-                                   * ( leaf_reflect_nir(ipft) - leaf_trans_nir(ipft)   )   &
-                                   * ( 1.d0 + orient_factor(ipft)) ** 2 )                  &
-                                 / ( 2.d0 * leaf_scatter_nir(ipft) )
-      wood_backscatter_nir(ipft) = ( wood_scatter_nir(ipft)                                &
-                                   + 2.5d-1                                                &
-                                   * ( wood_reflect_nir(ipft) - wood_trans_nir(ipft)   )   &
-                                   * ( 1.d0 + orient_factor(ipft)) ** 2 )                  &
-                                 / ( 2.d0 * wood_scatter_nir(ipft) )
       !------------------------------------------------------------------------------------!
       !      Thermal infra-red (TIR): Here we use the same expression from CLM manual,     !
       ! further assuming that the transmittance is zero like Zhao and Qualls (2006) did,   !


### PR DESCRIPTION
Due to issues with compilation flags, I found two bugs resulting from my transferring the radiative equations from ed_params to radiative driver. One was a remnant code left in the ed_params, which caused issues if debugging flag was activated during compilation. The second bug was a weird one, which came up if the mpi flag was used during compilation. Essentially I just had to move the added equations in the code to another place and it no longer crashed the compilation.

As a warning, I still get crashes when running with the debugging flags, but they seem to be connected to water level equations which I have not touched at all and I did not see the radiation equations affecting them at all, so I did yet check what was causing that.