### PR TITLE
Completely removed vleaf respiration from the model.

### DIFF
--- a/ED/src/dynamics/growth_balive.f90
+++ b/ED/src/dynamics/growth_balive.f90
@@ -183,16 +183,6 @@ module growth_balive
 
 
                   !------------------------------------------------------------------------!
-                  !     Find the "virtual" leaf respiration.                               !
-                  !------------------------------------------------------------------------!
-                  cpatch%vleaf_respiration(ico) = (1.0-cpoly%green_leaf_factor(ipft,isi))  &
-                                                * salloci * cpatch%balive(ico)             &
-                                                * storage_turnover_rate(ipft)              &
-                                                * tfact * temp_dep
-                  !------------------------------------------------------------------------!
-
-
-                  !------------------------------------------------------------------------!
                   !      Allocate plant carbon balance to balive and bstorage.             !
                   !------------------------------------------------------------------------!
                   balive_in = cpatch%balive(ico)
@@ -480,16 +470,6 @@ module growth_balive
                                                           * growth_resp_factor(ipft))
                   !------------------------------------------------------------------------!
 
-
-
-                  !------------------------------------------------------------------------!
-                  !     Find the "virtual" leaf respiration.                               !
-                  !------------------------------------------------------------------------!
-                  cpatch%vleaf_respiration(ico) = (1.0-cpoly%green_leaf_factor(ipft,isi))  &
-                                                * salloci * cpatch%balive(ico)             &
-                                                * storage_turnover_rate(ipft)              &
-                                                * tfact * temp_dep
-                  !------------------------------------------------------------------------!
 
 
                   !------------------------------------------------------------------------!
@@ -804,8 +784,7 @@ module growth_balive
       !------------------------------------------------------------------------------------!
       !       Calculate actual daily carbon balance: kgC/plant/day.                        !
       !------------------------------------------------------------------------------------!
-      carbon_balance = daily_C_gain - cpatch%growth_respiration(ico)                       &
-                                    - cpatch%vleaf_respiration(ico)
+      carbon_balance = daily_C_gain - cpatch%growth_respiration(ico)
       !------------------------------------------------------------------------------------!
 
       if (cpatch%nplant(ico) > tiny(1.0)) then
@@ -819,8 +798,7 @@ module growth_balive
                                                          - cpatch%today_root_resp(ico))    &
                                                        / cpatch%nplant(ico)
          growth_respiration_pot = max(0.0, daily_C_gain_pot * growth_resp_factor(ipft))
-         carbon_balance_pot     = daily_C_gain_pot - growth_respiration_pot                &
-                                - cpatch%vleaf_respiration(ico)
+         carbon_balance_pot     = daily_C_gain_pot - growth_respiration_pot
          !---------------------------------------------------------------------------------!
 
 
@@ -837,8 +815,7 @@ module growth_balive
                                      / cpatch%nplant(ico)
          growth_respiration_lightmax = max(0.0, daily_C_gain_lightmax                      &
                                               * growth_resp_factor(ipft) )
-         carbon_balance_lightmax     = daily_C_gain_lightmax - growth_respiration_lightmax &
-                                     - cpatch%vleaf_respiration(ico)
+         carbon_balance_lightmax     = daily_C_gain_lightmax - growth_respiration_lightmax
          !------ Full soil moisture. ------------------------------------------------------!
          daily_C_gain_moistmax       = umol_2_kgC * day_sec                                &
                                      * ( cpatch%today_gpp_moistmax(ico)                    &
@@ -847,8 +824,7 @@ module growth_balive
                                      / cpatch%nplant(ico)
          growth_respiration_moistmax = max(0.0, daily_C_gain_moistmax                      &
                                               * growth_resp_factor(ipft) )
-         carbon_balance_moistmax     = daily_C_gain_moistmax - growth_respiration_moistmax &
-                                     - cpatch%vleaf_respiration(ico)
+         carbon_balance_moistmax     = daily_C_gain_moistmax - growth_respiration_moistmax
          !------ Full soil moisture and light. --------------------------------------------!
          daily_C_gain_mlmax          = umol_2_kgC * day_sec                                &
                                      * ( cpatch%today_gpp_mlmax(ico)                       &
@@ -857,8 +833,7 @@ module growth_balive
                                      / cpatch%nplant(ico)
          growth_respiration_mlmax    = max(0.0, daily_C_gain_mlmax                         &
                                               * growth_resp_factor(ipft) )
-         carbon_balance_mlmax        = daily_C_gain_mlmax - growth_respiration_mlmax       &
-                                     - cpatch%vleaf_respiration(ico)
+         carbon_balance_mlmax        = daily_C_gain_mlmax - growth_respiration_mlmax
          !---------------------------------------------------------------------------------!
       else
          carbon_balance_pot      = 0.0
@@ -879,7 +854,7 @@ module growth_balive
             first_time(ipft) = .false.
             write (unit=30+ipft,fmt='(a10,21(1x,a18))')                                    &
                '      TIME','             PATCH','            COHORT','            NPLANT' &
-                           ,'          CB_TODAY','       GROWTH_RESP','        VLEAF_RESP' &
+                           ,'          CB_TODAY','       GROWTH_RESP'                      &
                            ,'         TODAY_GPP','TODAY_GPP_LIGHTMAX','TODAY_GPP_MOISTMAX' &
                            ,'   TODAY_GPP_MLMAX','   TODAY_LEAF_RESP','   TODAY_ROOT_RESP' &
                            ,' CB_LIGHTMAX_TODAY',' CB_MOISTMAX_TODAY','    CB_MLMAX_TODAY' &
@@ -890,7 +865,7 @@ module growth_balive
          write(unit=30+ipft,fmt='(2(i2.2,a1),i4.4,2(1x,i18),19(1x,es18.5))')               &
               current_time%month,'/',current_time%date,'/',current_time%year               &
              ,ipa,ico,cpatch%nplant(ico),carbon_balance,cpatch%growth_respiration(ico)     &
-             ,cpatch%vleaf_respiration(ico),cpatch%today_gpp(ico)                          &
+             ,cpatch%today_gpp(ico)                                                        &
              ,cpatch%today_gpp_lightmax(ico),cpatch%today_gpp_moistmax(ico)                &
              ,cpatch%today_gpp_mlmax(ico),cpatch%today_leaf_resp(ico)                      &
              ,cpatch%today_root_resp(ico),carbon_balance_lightmax,carbon_balance_moistmax  &

--- a/ED/src/dynamics/hybrid_driver.f90
+++ b/ED/src/dynamics/hybrid_driver.f90
@@ -882,7 +882,6 @@ subroutine hybrid_timestep(cgrid)
       targetp%root_resp       (k) = sourcep%root_resp       (k)
       targetp%growth_resp     (k) = sourcep%growth_resp     (k)
       targetp%storage_resp    (k) = sourcep%storage_resp    (k)
-      targetp%vleaf_resp      (k) = sourcep%vleaf_resp      (k)
    end do
 
    if (checkbudget) then

--- a/ED/src/dynamics/photosyn_driv.f90
+++ b/ED/src/dynamics/photosyn_driv.f90
@@ -580,9 +580,6 @@ subroutine canopy_photosynthesis(csite,cmet,mzg,ipa,lsl,ntext_soil              
       cpatch%fmean_storage_resp(ico) = cpatch%fmean_storage_resp (ico)                     &
                                      + cpatch%storage_respiration(ico) * dtlsm_o_frqsum    &
                                      * yr_day
-      cpatch%fmean_vleaf_resp  (ico) = cpatch%fmean_vleaf_resp   (ico)                     &
-                                     + cpatch%vleaf_respiration  (ico) * dtlsm_o_frqsum    &
-                                     * yr_day
       !------------------------------------------------------------------------------------!
 
       if (print_photo_debug) then

--- a/ED/src/dynamics/rk4_derivs.F90
+++ b/ED/src/dynamics/rk4_derivs.F90
@@ -1292,7 +1292,7 @@ subroutine canopy_derivs_two(mzg,initp,dinitp,csite,ipa,hflxsc,wflxsc,qwflxsc,hf
       !                 to lack of a better place to put).                                 !
       ! Leaf   -> CAS : Leaf respiration, Virtual leaf respiration - GPP.                  !
       !------------------------------------------------------------------------------------!
-      cflxlc_tot    = cflxlc_tot + initp%vleaf_resp(ico)
+      cflxlc_tot    = cflxlc_tot
       cflxwc_tot    = cflxwc_tot + initp%growth_resp(ico) + initp%storage_resp(ico)
       !------------------------------------------------------------------------------------!
 

--- a/ED/src/dynamics/rk4_integ_utils.f90
+++ b/ED/src/dynamics/rk4_integ_utils.f90
@@ -1356,7 +1356,6 @@ subroutine copy_rk4_patch(sourcep, targetp, cpatch)
       targetp%root_resp       (k) = sourcep%root_resp       (k)
       targetp%growth_resp     (k) = sourcep%growth_resp     (k)
       targetp%storage_resp    (k) = sourcep%storage_resp    (k)
-      targetp%vleaf_resp      (k) = sourcep%vleaf_resp      (k)
    end do
 
    if (checkbudget) then

--- a/ED/src/dynamics/rk4_misc.f90
+++ b/ED/src/dynamics/rk4_misc.f90
@@ -516,8 +516,6 @@ subroutine copy_patch_init_carbon(sourcesite,ipa,targetp)
                                 * targetp%nplant(ico) / (day_sec8 * umol_2_kgC8)
       targetp%storage_resp(ico) = dble(cpatch%storage_respiration(ico))                    &
                                 * targetp%nplant(ico) / (day_sec8 * umol_2_kgC8)
-      targetp%vleaf_resp  (ico) = dble(cpatch%vleaf_respiration  (ico))                    &
-                                * targetp%nplant(ico) / (day_sec8 * umol_2_kgC8)
    end do
 
    !----- Heterotrophic respiration terms. ------------------------------------------------!
@@ -3468,7 +3466,6 @@ subroutine print_csiteipa(csite, ipa)
    integer                      :: k
    real                         :: growth_resp
    real                         :: storage_resp
-   real                         :: vleaf_resp
    real                         :: pss_lai
    real                         :: pss_wai
    !---------------------------------------------------------------------------------------!
@@ -3525,20 +3522,16 @@ subroutine print_csiteipa(csite, ipa)
       end if
    end do
    write (unit=*,fmt='(2(a7,1x),5(a12,1x))')                                               &
-         '    PFT','KRDEPTH','         LAI','   ROOT_RESP',' GROWTH_RESP','   STOR_RESP'   &
-                            ,'  VLEAF_RESP'
+         '    PFT','KRDEPTH','         LAI','   ROOT_RESP',' GROWTH_RESP','   STOR_RESP'
    do ico = 1,cpatch%ncohorts
       if (cpatch%leaf_resolvable(ico)) then
          growth_resp  = cpatch%growth_respiration(ico)  * cpatch%nplant(ico)               &
                       / (day_sec * umol_2_kgC)
          storage_resp = cpatch%storage_respiration(ico) * cpatch%nplant(ico)               &
                       / (day_sec * umol_2_kgC)
-         vleaf_resp   = cpatch%vleaf_respiration(ico)  * cpatch%nplant(ico)                &
-                      / (day_sec * umol_2_kgC)
 
          write(unit=*,fmt='(2(i7,1x),5(es12.4,1x))') cpatch%pft(ico), cpatch%krdepth(ico)  &
-              ,cpatch%lai(ico),cpatch%root_respiration(ico),growth_resp,storage_resp       &
-              ,vleaf_resp
+              ,cpatch%lai(ico),cpatch%root_respiration(ico),growth_resp,storage_resp
       end if
    end do
    write (unit=*,fmt='(a)'  ) ' '
@@ -3752,12 +3745,12 @@ subroutine print_rk4patch(y,csite,ipa)
    write (unit=*,fmt='(80a)') ('-',k=1,80)
    write (unit=*,fmt='(2(a7,1x),7(a12,1x))')                                               &
          '    PFT','KRDEPTH','         LAI','         GPP','   LEAF_RESP','   ROOT_RESP'   &
-                            ,' GROWTH_RESP','   STOR_RESP','  VLEAF_RESP'
+                            ,' GROWTH_RESP','   STOR_RESP'
    do ico = 1,cpatch%ncohorts
       if (cpatch%leaf_resolvable(ico)) then
          write(unit=*,fmt='(2(i7,1x),7(es12.4,1x))') cpatch%pft(ico), cpatch%krdepth(ico)  &
               ,y%lai(ico),y%gpp(ico),y%leaf_resp(ico),y%root_resp(ico),y%growth_resp(ico)  &
-              ,y%storage_resp(ico),y%vleaf_resp(ico)
+              ,y%storage_resp(ico)
       end if
    end do
    write (unit=*,fmt='(80a)') ('-',k=1,80)
@@ -4057,8 +4050,7 @@ subroutine print_rk4_state(initp,fluxp,csite,ipa,isi,elapsed,hdid)
          sum_plresp      = sum_plresp      + initp%leaf_resp(ico)                          &
                                            + initp%root_resp(ico)                          &
                                            + initp%growth_resp(ico)                        &
-                                           + initp%storage_resp(ico)                       &
-                                           + initp%vleaf_resp(ico)
+                                           + initp%storage_resp(ico)
       end if
       if (initp%wood_resolvable(ico)) then
          !----- Integrate vegetation properties using m2gnd rather than plant. ------------!
@@ -4310,7 +4302,7 @@ subroutine print_rk4_state(initp,fluxp,csite,ipa,isi,elapsed,hdid)
             , initp%wood_gbh(ico)     , initp%wood_gbw(ico)     , initp%gsw_open(ico)      &
             , initp%gsw_closed(ico)   , initp%gpp(ico)          , initp%leaf_resp(ico)     &
             , initp%root_resp(ico)    , initp%growth_resp(ico)  , initp%storage_resp(ico)  &
-            , initp%vleaf_resp(ico)   , initp%rshort_l(ico)     , initp%rlong_l(ico)       &
+                                      , initp%rshort_l(ico)     , initp%rlong_l(ico)       &
             , initp%rshort_w(ico)     , initp%rlong_w(ico)      , fluxp%cfx_hflxlc(ico)    &
             , fluxp%cfx_hflxwc(ico)   , fluxp%cfx_qwflxlc(ico)  , fluxp%cfx_qwflxwc(ico)   &
             , fluxp%cfx_qwshed(ico)   , fluxp%cfx_qtransp(ico)  , qintercepted

--- a/ED/src/init/ed_type_init.f90
+++ b/ED/src/init/ed_type_init.f90
@@ -157,7 +157,6 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
    cpatch%root_respiration      (ico) = 0.0
    cpatch%growth_respiration    (ico) = 0.0
    cpatch%storage_respiration   (ico) = 0.0
-   cpatch%vleaf_respiration     (ico) = 0.0
    cpatch%monthly_dndt          (ico) = 0.0
    cpatch%monthly_dlnndt        (ico) = 0.0
    cpatch%mort_rate           (:,ico) = 0.0
@@ -235,7 +234,6 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
    cpatch%fmean_root_resp         (ico) = 0.0
    cpatch%fmean_growth_resp       (ico) = 0.0
    cpatch%fmean_storage_resp      (ico) = 0.0
-   cpatch%fmean_vleaf_resp        (ico) = 0.0
    cpatch%fmean_plresp            (ico) = 0.0
    cpatch%fmean_leaf_energy       (ico) = 0.0
    cpatch%fmean_leaf_water        (ico) = 0.0
@@ -307,7 +305,6 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
       cpatch%dmean_root_resp         (ico) = 0.0
       cpatch%dmean_growth_resp       (ico) = 0.0
       cpatch%dmean_storage_resp      (ico) = 0.0
-      cpatch%dmean_vleaf_resp        (ico) = 0.0
       cpatch%dmean_plresp            (ico) = 0.0
       cpatch%dmean_leaf_energy       (ico) = 0.0
       cpatch%dmean_leaf_water        (ico) = 0.0
@@ -372,7 +369,6 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
       cpatch%mmean_root_resp           (ico) = 0.0
       cpatch%mmean_growth_resp         (ico) = 0.0
       cpatch%mmean_storage_resp        (ico) = 0.0
-      cpatch%mmean_vleaf_resp          (ico) = 0.0
       cpatch%mmean_plresp              (ico) = 0.0
       cpatch%mmean_leaf_energy         (ico) = 0.0
       cpatch%mmean_leaf_water          (ico) = 0.0
@@ -462,7 +458,6 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
       cpatch%qmean_root_resp         (:,ico) = 0.0
       cpatch%qmean_growth_resp       (:,ico) = 0.0
       cpatch%qmean_storage_resp      (:,ico) = 0.0
-      cpatch%qmean_vleaf_resp        (:,ico) = 0.0
       cpatch%qmean_plresp            (:,ico) = 0.0
       cpatch%qmean_leaf_energy       (:,ico) = 0.0
       cpatch%qmean_leaf_water        (:,ico) = 0.0
@@ -1441,7 +1436,6 @@ subroutine init_ed_poly_vars(cgrid)
       cgrid%fmean_root_resp            (ipy) = 0.0
       cgrid%fmean_growth_resp          (ipy) = 0.0
       cgrid%fmean_storage_resp         (ipy) = 0.0
-      cgrid%fmean_vleaf_resp           (ipy) = 0.0
       cgrid%fmean_plresp               (ipy) = 0.0
       cgrid%fmean_leaf_energy          (ipy) = 0.0
       cgrid%fmean_leaf_water           (ipy) = 0.0
@@ -1585,7 +1579,6 @@ subroutine init_ed_poly_vars(cgrid)
          cgrid%dmean_root_resp            (ipy) = 0.0
          cgrid%dmean_growth_resp          (ipy) = 0.0
          cgrid%dmean_storage_resp         (ipy) = 0.0
-         cgrid%dmean_vleaf_resp           (ipy) = 0.0
          cgrid%dmean_plresp               (ipy) = 0.0
          cgrid%dmean_leaf_energy          (ipy) = 0.0
          cgrid%dmean_leaf_water           (ipy) = 0.0
@@ -1716,7 +1709,6 @@ subroutine init_ed_poly_vars(cgrid)
          cgrid%mmean_root_resp            (ipy) = 0.0
          cgrid%mmean_growth_resp          (ipy) = 0.0
          cgrid%mmean_storage_resp         (ipy) = 0.0
-         cgrid%mmean_vleaf_resp           (ipy) = 0.0
          cgrid%mmean_plresp               (ipy) = 0.0
          cgrid%mmean_leaf_energy          (ipy) = 0.0
          cgrid%mmean_leaf_water           (ipy) = 0.0
@@ -1901,7 +1893,6 @@ subroutine init_ed_poly_vars(cgrid)
          cgrid%qmean_root_resp          (:,ipy) = 0.0
          cgrid%qmean_growth_resp        (:,ipy) = 0.0
          cgrid%qmean_storage_resp       (:,ipy) = 0.0
-         cgrid%qmean_vleaf_resp         (:,ipy) = 0.0
          cgrid%qmean_plresp             (:,ipy) = 0.0
          cgrid%qmean_leaf_energy        (:,ipy) = 0.0
          cgrid%qmean_leaf_water         (:,ipy) = 0.0

--- a/ED/src/io/average_utils.f90
+++ b/ED/src/io/average_utils.f90
@@ -189,10 +189,6 @@ module average_utils
                                                   + cpatch%fmean_storage_resp  (ico)       &
                                                   * cpatch%nplant              (ico)       &
                                                   * patch_wgt
-                  cgrid%fmean_vleaf_resp    (ipy) = cgrid%fmean_vleaf_resp     (ipy)       &
-                                                  + cpatch%fmean_vleaf_resp    (ico)       &
-                                                  * cpatch%nplant              (ico)       &
-                                                  * patch_wgt
                   cgrid%fmean_plresp        (ipy) = cgrid%fmean_plresp         (ipy)       &
                                                   + cpatch%fmean_plresp        (ico)       &
                                                   * cpatch%nplant              (ico)       &
@@ -1109,8 +1105,7 @@ module average_utils
                   cpatch%fmean_plresp(ico) = cpatch%fmean_leaf_resp   (ico)                &
                                            + cpatch%fmean_root_resp   (ico)                &
                                            + cpatch%fmean_storage_resp(ico)                &
-                                           + cpatch%fmean_growth_resp (ico)                &
-                                           + cpatch%fmean_vleaf_resp  (ico)
+                                           + cpatch%fmean_growth_resp (ico)
                   cpatch%fmean_npp   (ico) = cpatch%fmean_gpp         (ico)                &
                                            - cpatch%fmean_plresp      (ico)
                   !------------------------------------------------------------------------!
@@ -1209,7 +1204,6 @@ module average_utils
          cgrid%fmean_root_resp       (  ipy) = 0.0
          cgrid%fmean_growth_resp     (  ipy) = 0.0
          cgrid%fmean_storage_resp    (  ipy) = 0.0
-         cgrid%fmean_vleaf_resp      (  ipy) = 0.0
          cgrid%fmean_plresp          (  ipy) = 0.0
          cgrid%fmean_leaf_energy     (  ipy) = 0.0
          cgrid%fmean_leaf_water      (  ipy) = 0.0
@@ -1448,7 +1442,6 @@ module average_utils
                   cpatch%fmean_root_resp         (ico) = 0.0
                   cpatch%fmean_growth_resp       (ico) = 0.0
                   cpatch%fmean_storage_resp      (ico) = 0.0
-                  cpatch%fmean_vleaf_resp        (ico) = 0.0
                   cpatch%fmean_plresp            (ico) = 0.0
                   cpatch%fmean_leaf_energy       (ico) = 0.0
                   cpatch%fmean_leaf_water        (ico) = 0.0
@@ -1617,9 +1610,6 @@ module average_utils
                                           * frqsum_o_daysec
          cgrid%dmean_storage_resp   (ipy) = cgrid%dmean_storage_resp   (ipy)               &
                                           + cgrid%fmean_storage_resp   (ipy)               &
-                                          * frqsum_o_daysec
-         cgrid%dmean_vleaf_resp     (ipy) = cgrid%dmean_vleaf_resp     (ipy)               &
-                                          + cgrid%fmean_vleaf_resp     (ipy)               &
                                           * frqsum_o_daysec
          cgrid%dmean_plresp         (ipy) = cgrid%dmean_plresp         (ipy)               &
                                           + cgrid%fmean_plresp         (ipy)               &
@@ -2180,9 +2170,6 @@ module average_utils
                                                    * frqsum_o_daysec
                   cpatch%dmean_storage_resp  (ico) = cpatch%dmean_storage_resp  (ico)      &
                                                    + cpatch%fmean_storage_resp  (ico)      &
-                                                   * frqsum_o_daysec
-                  cpatch%dmean_vleaf_resp    (ico) = cpatch%dmean_vleaf_resp    (ico)      &
-                                                   + cpatch%fmean_vleaf_resp    (ico)      &
                                                    * frqsum_o_daysec
                   cpatch%dmean_plresp        (ico) = cpatch%dmean_plresp        (ico)      &
                                                    + cpatch%fmean_plresp        (ico)      &
@@ -3104,7 +3091,6 @@ module average_utils
          cgrid%dmean_root_resp          (ipy) = 0.0
          cgrid%dmean_growth_resp        (ipy) = 0.0
          cgrid%dmean_storage_resp       (ipy) = 0.0
-         cgrid%dmean_vleaf_resp         (ipy) = 0.0
          cgrid%dmean_plresp             (ipy) = 0.0
          cgrid%dmean_leaf_energy        (ipy) = 0.0
          cgrid%dmean_leaf_water         (ipy) = 0.0
@@ -3333,7 +3319,6 @@ module average_utils
                   cpatch%dmean_root_resp         (ico) = 0.0
                   cpatch%dmean_growth_resp       (ico) = 0.0
                   cpatch%dmean_storage_resp      (ico) = 0.0
-                  cpatch%dmean_vleaf_resp        (ico) = 0.0
                   cpatch%dmean_plresp            (ico) = 0.0
                   cpatch%dmean_leaf_energy       (ico) = 0.0
                   cpatch%dmean_leaf_water        (ico) = 0.0
@@ -3562,9 +3547,6 @@ module average_utils
                                             * ndaysi
          cgrid%mmean_storage_resp     (ipy) = cgrid%mmean_storage_resp     (ipy)           &
                                             + cgrid%dmean_storage_resp     (ipy)           &
-                                            * ndaysi
-         cgrid%mmean_vleaf_resp       (ipy) = cgrid%mmean_vleaf_resp       (ipy)           &
-                                            + cgrid%dmean_vleaf_resp       (ipy)           &
                                             * ndaysi
          cgrid%mmean_plresp           (ipy) = cgrid%mmean_plresp           (ipy)           &
                                             + cgrid%dmean_plresp           (ipy)           &
@@ -4413,9 +4395,6 @@ module average_utils
                   cpatch%mmean_storage_resp    (ico) = cpatch%mmean_storage_resp    (ico)  &
                                                      + cpatch%dmean_storage_resp    (ico)  &
                                                      * ndaysi
-                  cpatch%mmean_vleaf_resp      (ico) = cpatch%mmean_vleaf_resp      (ico)  &
-                                                     + cpatch%dmean_vleaf_resp      (ico)  &
-                                                     * ndaysi
                   cpatch%mmean_plresp          (ico) = cpatch%mmean_plresp          (ico)  &
                                                      + cpatch%dmean_plresp          (ico)  &
                                                      * ndaysi
@@ -5014,7 +4993,6 @@ module average_utils
          cgrid%mmean_root_resp           (ipy) = 0.0 
          cgrid%mmean_growth_resp         (ipy) = 0.0 
          cgrid%mmean_storage_resp        (ipy) = 0.0 
-         cgrid%mmean_vleaf_resp          (ipy) = 0.0 
          cgrid%mmean_plresp              (ipy) = 0.0 
          cgrid%mmean_leaf_energy         (ipy) = 0.0 
          cgrid%mmean_leaf_water          (ipy) = 0.0 
@@ -5320,7 +5298,6 @@ module average_utils
                   cpatch%mmean_root_resp         (ico) = 0.0
                   cpatch%mmean_growth_resp       (ico) = 0.0
                   cpatch%mmean_storage_resp      (ico) = 0.0
-                  cpatch%mmean_vleaf_resp        (ico) = 0.0
                   cpatch%mmean_plresp            (ico) = 0.0
                   cpatch%mmean_leaf_energy       (ico) = 0.0
                   cpatch%mmean_leaf_water        (ico) = 0.0
@@ -5512,9 +5489,6 @@ module average_utils
                                               * ndaysi
          cgrid%qmean_storage_resp     (t,ipy) = cgrid%qmean_storage_resp     (t,ipy)       &
                                               + cgrid%fmean_storage_resp       (ipy)       &
-                                              * ndaysi
-         cgrid%qmean_vleaf_resp       (t,ipy) = cgrid%qmean_vleaf_resp       (t,ipy)       &
-                                              + cgrid%fmean_vleaf_resp         (ipy)       &
                                               * ndaysi
          cgrid%qmean_plresp           (t,ipy) = cgrid%qmean_plresp           (t,ipy)       &
                                               + cgrid%fmean_plresp             (ipy)       &
@@ -6201,9 +6175,6 @@ module average_utils
                   cpatch%qmean_storage_resp  (t,ico) = cpatch%qmean_storage_resp  (t,ico)  &
                                                      + cpatch%fmean_storage_resp    (ico)  &
                                                      * ndaysi
-                  cpatch%qmean_vleaf_resp    (t,ico) = cpatch%qmean_vleaf_resp    (t,ico)  &
-                                                     + cpatch%fmean_vleaf_resp      (ico)  &
-                                                     * ndaysi
                   cpatch%qmean_plresp        (t,ico) = cpatch%qmean_plresp        (t,ico)  &
                                                      + cpatch%fmean_plresp          (ico)  &
                                                      * ndaysi
@@ -6767,7 +6738,6 @@ module average_utils
          cgrid%qmean_root_resp          (:,ipy) = 0.0
          cgrid%qmean_growth_resp        (:,ipy) = 0.0
          cgrid%qmean_storage_resp       (:,ipy) = 0.0
-         cgrid%qmean_vleaf_resp         (:,ipy) = 0.0
          cgrid%qmean_plresp             (:,ipy) = 0.0
          cgrid%qmean_leaf_energy        (:,ipy) = 0.0
          cgrid%qmean_leaf_water         (:,ipy) = 0.0
@@ -7023,7 +6993,6 @@ module average_utils
                   cpatch%qmean_root_resp           (:,ico) = 0.0
                   cpatch%qmean_growth_resp         (:,ico) = 0.0
                   cpatch%qmean_storage_resp        (:,ico) = 0.0
-                  cpatch%qmean_vleaf_resp          (:,ico) = 0.0
                   cpatch%qmean_plresp              (:,ico) = 0.0
                   cpatch%qmean_leaf_energy         (:,ico) = 0.0
                   cpatch%qmean_leaf_water          (:,ico) = 0.0

--- a/ED/src/io/ed_init_full_history.F90
+++ b/ED/src/io/ed_init_full_history.F90
@@ -913,8 +913,6 @@ subroutine fill_history_grid_p11dmean(cgrid,ipy,py_index)
                         ,'DMEAN_GROWTH_RESP_PY      ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cgrid%dmean_storage_resp   (ipy:ipy)                              &
                         ,'DMEAN_STORAGE_RESP_PY     ',dsetrank,iparallel,.false.,foundvar)
-      call hdf_getslab_r(cgrid%dmean_vleaf_resp     (ipy:ipy)                              &
-                        ,'DMEAN_VLEAF_RESP_PY       ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cgrid%dmean_plresp         (ipy:ipy)                              &
                         ,'DMEAN_PLRESP_PY           ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cgrid%dmean_leaf_energy    (ipy:ipy)                              &
@@ -1306,8 +1304,6 @@ subroutine fill_history_grid_p11mmean(cgrid,ipy,py_index)
                         ,'MMEAN_GROWTH_RESP_PY      ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cgrid%mmean_storage_resp   (ipy:ipy)                              &
                         ,'MMEAN_STORAGE_RESP_PY     ',dsetrank,iparallel,.false.,foundvar)
-      call hdf_getslab_r(cgrid%mmean_vleaf_resp     (ipy:ipy)                              &
-                        ,'MMEAN_VLEAF_RESP_PY       ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cgrid%mmean_plresp         (ipy:ipy)                              &
                         ,'MMEAN_PLRESP_PY           ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cgrid%mmean_leaf_energy    (ipy:ipy)                              &
@@ -1969,8 +1965,6 @@ subroutine fill_history_grid_m11(cgrid,ipy,py_index)
                         ,'QMEAN_GROWTH_RESP_PY     ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cgrid%qmean_storage_resp   (:,ipy)                                &
                         ,'QMEAN_STORAGE_RESP_PY    ',dsetrank,iparallel,.false.,foundvar)
-      call hdf_getslab_r(cgrid%qmean_vleaf_resp     (:,ipy)                                &
-                        ,'QMEAN_VLEAF_RESP_PY      ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cgrid%qmean_plresp         (:,ipy)                                &
                         ,'QMEAN_PLRESP_PY          ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cgrid%qmean_leaf_energy    (:,ipy)                                &
@@ -5008,8 +5002,6 @@ subroutine fill_history_patch(cpatch,paco_index,ncohorts_global)
                      ,'GROWTH_RESPIRATION        ',dsetrank,iparallel,.true. ,foundvar)
    call hdf_getslab_r(cpatch%storage_respiration                                           &
                      ,'STORAGE_RESPIRATION       ',dsetrank,iparallel,.true. ,foundvar)
-   call hdf_getslab_r(cpatch%vleaf_respiration                                             &
-                     ,'VLEAF_RESPIRATION         ',dsetrank,iparallel,.true. ,foundvar)
    call hdf_getslab_r(cpatch%monthly_dndt                                                  &
                      ,'MONTHLY_DNDT              ',dsetrank,iparallel,.true. ,foundvar)
    call hdf_getslab_r(cpatch%monthly_dlnndt                                                &
@@ -5138,8 +5130,6 @@ subroutine fill_history_patch(cpatch,paco_index,ncohorts_global)
                         ,'DMEAN_GROWTH_RESP_CO      ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cpatch%dmean_storage_resp                                         &
                         ,'DMEAN_STORAGE_RESP_CO     ',dsetrank,iparallel,.false.,foundvar)
-      call hdf_getslab_r(cpatch%dmean_vleaf_resp                                           &
-                        ,'DMEAN_VLEAF_RESP_CO       ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cpatch%dmean_plresp                                               &
                         ,'DMEAN_PLRESP_CO           ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cpatch%dmean_leaf_energy                                          &
@@ -5266,8 +5256,6 @@ subroutine fill_history_patch(cpatch,paco_index,ncohorts_global)
                         ,'MMEAN_GROWTH_RESP_CO      ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cpatch%mmean_storage_resp                                         &
                         ,'MMEAN_STORAGE_RESP_CO     ',dsetrank,iparallel,.false.,foundvar)
-      call hdf_getslab_r(cpatch%mmean_vleaf_resp                                           &
-                        ,'MMEAN_VLEAF_RESP_CO       ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cpatch%mmean_plresp                                               &
                         ,'MMEAN_PLRESP_CO           ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cpatch%mmean_leaf_energy                                          &
@@ -5540,8 +5528,6 @@ subroutine fill_history_patch(cpatch,paco_index,ncohorts_global)
                         ,'QMEAN_GROWTH_RESP_CO      ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cpatch%qmean_storage_resp                                         &
                         ,'QMEAN_STORAGE_RESP_CO     ',dsetrank,iparallel,.false.,foundvar)
-      call hdf_getslab_r(cpatch%qmean_vleaf_resp                                           &
-                        ,'QMEAN_VLEAF_RESP_CO       ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cpatch%qmean_plresp                                               &
                         ,'QMEAN_PLRESP_CO           ',dsetrank,iparallel,.false.,foundvar)
       call hdf_getslab_r(cpatch%qmean_leaf_energy                                          &

--- a/ED/src/memory/ed_state_vars.F90
+++ b/ED/src/memory/ed_state_vars.F90
@@ -304,8 +304,6 @@ module ed_state_vars
       real ,pointer,dimension(:) :: growth_respiration
       ! Plant storage respiration (kgC/plant/day)
       real ,pointer,dimension(:) :: storage_respiration
-      ! Plant virtual leaf respiration (kgC/plant/day)
-      real ,pointer,dimension(:) :: vleaf_respiration
 
       ! Plant density tendency [plants/m2/month]
       real ,pointer,dimension(:) :: monthly_dndt
@@ -493,7 +491,6 @@ module ed_state_vars
       real,pointer,dimension(:)   :: fmean_root_resp        ! Root respiration  [ kgC/pl/yr]
       real,pointer,dimension(:)   :: fmean_growth_resp      ! Growth resp.      [ kgC/pl/yr]
       real,pointer,dimension(:)   :: fmean_storage_resp     ! Storage resp.     [ kgC/pl/yr]
-      real,pointer,dimension(:)   :: fmean_vleaf_resp       ! Virt. leaf resp.  [ kgC/pl/yr]
       real,pointer,dimension(:)   :: fmean_plresp           ! Plant resp.       [ kgC/pl/yr]
       real,pointer,dimension(:)   :: fmean_leaf_energy      ! Leaf int. energy  [     J/m2g]
       real,pointer,dimension(:)   :: fmean_leaf_water       ! Leaf sfc. water   [    kg/m2g]
@@ -566,7 +563,6 @@ module ed_state_vars
       real,pointer,dimension(:)     :: dmean_root_resp
       real,pointer,dimension(:)     :: dmean_growth_resp
       real,pointer,dimension(:)     :: dmean_storage_resp
-      real,pointer,dimension(:)     :: dmean_vleaf_resp
       real,pointer,dimension(:)     :: dmean_plresp
       real,pointer,dimension(:)     :: dmean_leaf_energy
       real,pointer,dimension(:)     :: dmean_leaf_water
@@ -623,7 +619,6 @@ module ed_state_vars
       real,pointer,dimension(:)     :: mmean_root_resp
       real,pointer,dimension(:)     :: mmean_growth_resp
       real,pointer,dimension(:)     :: mmean_storage_resp
-      real,pointer,dimension(:)     :: mmean_vleaf_resp
       real,pointer,dimension(:)     :: mmean_plresp
       real,pointer,dimension(:)     :: mmean_leaf_energy
       real,pointer,dimension(:)     :: mmean_leaf_water
@@ -696,7 +691,6 @@ module ed_state_vars
       real,pointer,dimension(:,:)   :: qmean_root_resp
       real,pointer,dimension(:,:)   :: qmean_growth_resp
       real,pointer,dimension(:,:)   :: qmean_storage_resp
-      real,pointer,dimension(:,:)   :: qmean_vleaf_resp
       real,pointer,dimension(:,:)   :: qmean_plresp
       real,pointer,dimension(:,:)   :: qmean_leaf_energy
       real,pointer,dimension(:,:)   :: qmean_leaf_water
@@ -2183,7 +2177,6 @@ module ed_state_vars
       real,pointer,dimension(:) :: fmean_root_resp        ! Root respiration    [ kgC/m2/yr]
       real,pointer,dimension(:) :: fmean_growth_resp      ! Growth resp.        [ kgC/m2/yr]
       real,pointer,dimension(:) :: fmean_storage_resp     ! Storage resp.       [ kgC/m2/yr]
-      real,pointer,dimension(:) :: fmean_vleaf_resp       ! Virt. leaf resp.    [ kgC/m2/yr]
       real,pointer,dimension(:) :: fmean_plresp           ! Plant respiration.  [ kgC/m2/yr]
       real,pointer,dimension(:) :: fmean_leaf_energy      ! Leaf int. energy    [      J/m2]
       real,pointer,dimension(:) :: fmean_leaf_water       ! Leaf sfc. water     [     kg/m2]
@@ -2346,7 +2339,6 @@ module ed_state_vars
       real,pointer,dimension(:)     :: dmean_root_resp
       real,pointer,dimension(:)     :: dmean_growth_resp
       real,pointer,dimension(:)     :: dmean_storage_resp
-      real,pointer,dimension(:)     :: dmean_vleaf_resp
       real,pointer,dimension(:)     :: dmean_plresp
       real,pointer,dimension(:)     :: dmean_leaf_energy
       real,pointer,dimension(:)     :: dmean_leaf_water
@@ -2468,7 +2460,6 @@ module ed_state_vars
       real,pointer,dimension(:)     :: mmean_root_resp
       real,pointer,dimension(:)     :: mmean_growth_resp
       real,pointer,dimension(:)     :: mmean_storage_resp
-      real,pointer,dimension(:)     :: mmean_vleaf_resp
       real,pointer,dimension(:)     :: mmean_plresp
       real,pointer,dimension(:)     :: mmean_leaf_energy
       real,pointer,dimension(:)     :: mmean_leaf_water
@@ -2627,7 +2618,6 @@ module ed_state_vars
       real,pointer,dimension(:,:)   :: qmean_root_resp
       real,pointer,dimension(:,:)   :: qmean_growth_resp
       real,pointer,dimension(:,:)   :: qmean_storage_resp
-      real,pointer,dimension(:,:)   :: qmean_vleaf_resp
       real,pointer,dimension(:,:)   :: qmean_plresp
       real,pointer,dimension(:,:)   :: qmean_leaf_energy
       real,pointer,dimension(:,:)   :: qmean_leaf_water
@@ -3048,7 +3038,6 @@ module ed_state_vars
       allocate(cgrid%fmean_root_resp            (                    npolygons))
       allocate(cgrid%fmean_growth_resp          (                    npolygons))
       allocate(cgrid%fmean_storage_resp         (                    npolygons))
-      allocate(cgrid%fmean_vleaf_resp           (                    npolygons))
       allocate(cgrid%fmean_plresp               (                    npolygons))
       allocate(cgrid%fmean_leaf_energy          (                    npolygons))
       allocate(cgrid%fmean_leaf_water           (                    npolygons))
@@ -3191,7 +3180,6 @@ module ed_state_vars
          allocate(cgrid%dmean_root_resp        (                     npolygons))
          allocate(cgrid%dmean_growth_resp      (                     npolygons))
          allocate(cgrid%dmean_storage_resp     (                     npolygons))
-         allocate(cgrid%dmean_vleaf_resp       (                     npolygons))
          allocate(cgrid%dmean_plresp           (                     npolygons))
          allocate(cgrid%dmean_leaf_energy      (                     npolygons))
          allocate(cgrid%dmean_leaf_water       (                     npolygons))
@@ -3341,7 +3329,6 @@ module ed_state_vars
          allocate(cgrid%mmean_root_resp        (                     npolygons)) 
          allocate(cgrid%mmean_growth_resp      (                     npolygons)) 
          allocate(cgrid%mmean_storage_resp     (                     npolygons)) 
-         allocate(cgrid%mmean_vleaf_resp       (                     npolygons)) 
          allocate(cgrid%mmean_plresp           (                     npolygons)) 
          allocate(cgrid%mmean_leaf_energy      (                     npolygons)) 
          allocate(cgrid%mmean_leaf_water       (                     npolygons)) 
@@ -3509,7 +3496,6 @@ module ed_state_vars
          allocate(cgrid%qmean_root_resp        (             ndcycle,npolygons))
          allocate(cgrid%qmean_growth_resp      (             ndcycle,npolygons))
          allocate(cgrid%qmean_storage_resp     (             ndcycle,npolygons))
-         allocate(cgrid%qmean_vleaf_resp       (             ndcycle,npolygons))
          allocate(cgrid%qmean_plresp           (             ndcycle,npolygons))
          allocate(cgrid%qmean_leaf_energy      (             ndcycle,npolygons))
          allocate(cgrid%qmean_leaf_water       (             ndcycle,npolygons))
@@ -4446,7 +4432,6 @@ module ed_state_vars
       allocate(cpatch%today_nppdaily               (                    ncohorts))
       allocate(cpatch%growth_respiration           (                    ncohorts))
       allocate(cpatch%storage_respiration          (                    ncohorts))
-      allocate(cpatch%vleaf_respiration            (                    ncohorts))
       allocate(cpatch%monthly_dndt                 (                    ncohorts))
       allocate(cpatch%monthly_dlnndt               (                    ncohorts))
       allocate(cpatch%mort_rate                    (             n_mort,ncohorts))
@@ -4510,7 +4495,6 @@ module ed_state_vars
       allocate(cpatch%fmean_root_resp              (                    ncohorts))
       allocate(cpatch%fmean_growth_resp            (                    ncohorts))
       allocate(cpatch%fmean_storage_resp           (                    ncohorts))
-      allocate(cpatch%fmean_vleaf_resp             (                    ncohorts))
       allocate(cpatch%fmean_plresp                 (                    ncohorts))
       allocate(cpatch%fmean_leaf_energy            (                    ncohorts))
       allocate(cpatch%fmean_leaf_water             (                    ncohorts))
@@ -4576,7 +4560,6 @@ module ed_state_vars
          allocate(cpatch%dmean_root_resp           (                    ncohorts))
          allocate(cpatch%dmean_growth_resp         (                    ncohorts))
          allocate(cpatch%dmean_storage_resp        (                    ncohorts))
-         allocate(cpatch%dmean_vleaf_resp          (                    ncohorts))
          allocate(cpatch%dmean_plresp              (                    ncohorts))
          allocate(cpatch%dmean_leaf_energy         (                    ncohorts))
          allocate(cpatch%dmean_leaf_water          (                    ncohorts))
@@ -4644,7 +4627,6 @@ module ed_state_vars
          allocate(cpatch%mmean_root_resp           (                    ncohorts))
          allocate(cpatch%mmean_growth_resp         (                    ncohorts))
          allocate(cpatch%mmean_storage_resp        (                    ncohorts))
-         allocate(cpatch%mmean_vleaf_resp          (                    ncohorts))
          allocate(cpatch%mmean_plresp              (                    ncohorts))
          allocate(cpatch%mmean_leaf_energy         (                    ncohorts))
          allocate(cpatch%mmean_leaf_water          (                    ncohorts))
@@ -4718,7 +4700,6 @@ module ed_state_vars
          allocate(cpatch%qmean_root_resp           (            ndcycle,ncohorts))
          allocate(cpatch%qmean_growth_resp         (            ndcycle,ncohorts))
          allocate(cpatch%qmean_storage_resp        (            ndcycle,ncohorts))
-         allocate(cpatch%qmean_vleaf_resp          (            ndcycle,ncohorts))
          allocate(cpatch%qmean_plresp              (            ndcycle,ncohorts))
          allocate(cpatch%qmean_leaf_energy         (            ndcycle,ncohorts))
          allocate(cpatch%qmean_leaf_water          (            ndcycle,ncohorts))
@@ -4902,7 +4883,6 @@ module ed_state_vars
       nullify(cgrid%fmean_root_resp         )
       nullify(cgrid%fmean_growth_resp       )
       nullify(cgrid%fmean_storage_resp      )
-      nullify(cgrid%fmean_vleaf_resp        )
       nullify(cgrid%fmean_plresp            )
       nullify(cgrid%fmean_leaf_energy       )
       nullify(cgrid%fmean_leaf_water        )
@@ -5037,7 +5017,6 @@ module ed_state_vars
       nullify(cgrid%dmean_root_resp         )
       nullify(cgrid%dmean_growth_resp       )
       nullify(cgrid%dmean_storage_resp      )
-      nullify(cgrid%dmean_vleaf_resp        )
       nullify(cgrid%dmean_plresp            )
       nullify(cgrid%dmean_leaf_energy       )
       nullify(cgrid%dmean_leaf_water        )
@@ -5176,7 +5155,6 @@ module ed_state_vars
       nullify(cgrid%mmean_root_resp         )
       nullify(cgrid%mmean_growth_resp       )
       nullify(cgrid%mmean_storage_resp      )
-      nullify(cgrid%mmean_vleaf_resp        )
       nullify(cgrid%mmean_plresp            )
       nullify(cgrid%mmean_leaf_energy       )
       nullify(cgrid%mmean_leaf_water        )
@@ -5333,7 +5311,6 @@ module ed_state_vars
       nullify(cgrid%qmean_root_resp         )
       nullify(cgrid%qmean_growth_resp       )
       nullify(cgrid%qmean_storage_resp      )
-      nullify(cgrid%qmean_vleaf_resp        )
       nullify(cgrid%qmean_plresp            )
       nullify(cgrid%qmean_leaf_energy       )
       nullify(cgrid%qmean_leaf_water        )
@@ -6170,7 +6147,6 @@ module ed_state_vars
       nullify(cpatch%today_nppdaily        )
       nullify(cpatch%growth_respiration    )
       nullify(cpatch%storage_respiration   )
-      nullify(cpatch%vleaf_respiration     )
       nullify(cpatch%monthly_dndt          )
       nullify(cpatch%monthly_dlnndt        )
       nullify(cpatch%mort_rate             )
@@ -6233,7 +6209,6 @@ module ed_state_vars
       nullify(cpatch%fmean_root_resp       )
       nullify(cpatch%fmean_growth_resp     )
       nullify(cpatch%fmean_storage_resp    )
-      nullify(cpatch%fmean_vleaf_resp      )
       nullify(cpatch%fmean_plresp          )
       nullify(cpatch%fmean_leaf_energy     )
       nullify(cpatch%fmean_leaf_water      )
@@ -6296,7 +6271,6 @@ module ed_state_vars
       nullify(cpatch%dmean_root_resp       )
       nullify(cpatch%dmean_growth_resp     )
       nullify(cpatch%dmean_storage_resp    )
-      nullify(cpatch%dmean_vleaf_resp      )
       nullify(cpatch%dmean_plresp          )
       nullify(cpatch%dmean_leaf_energy     )
       nullify(cpatch%dmean_leaf_water      )
@@ -6361,7 +6335,6 @@ module ed_state_vars
       nullify(cpatch%mmean_root_resp       )
       nullify(cpatch%mmean_growth_resp     )
       nullify(cpatch%mmean_storage_resp    )
-      nullify(cpatch%mmean_vleaf_resp      )
       nullify(cpatch%mmean_plresp          )
       nullify(cpatch%mmean_leaf_energy     )
       nullify(cpatch%mmean_leaf_water      )
@@ -6432,7 +6405,6 @@ module ed_state_vars
       nullify(cpatch%qmean_root_resp       )
       nullify(cpatch%qmean_growth_resp     )
       nullify(cpatch%qmean_storage_resp    )
-      nullify(cpatch%qmean_vleaf_resp      )
       nullify(cpatch%qmean_plresp          )
       nullify(cpatch%qmean_leaf_energy     )
       nullify(cpatch%qmean_leaf_water      )
@@ -6625,7 +6597,6 @@ module ed_state_vars
       if(associated(cgrid%fmean_root_resp       )) deallocate(cgrid%fmean_root_resp       )
       if(associated(cgrid%fmean_growth_resp     )) deallocate(cgrid%fmean_growth_resp     )
       if(associated(cgrid%fmean_storage_resp    )) deallocate(cgrid%fmean_storage_resp    )
-      if(associated(cgrid%fmean_vleaf_resp      )) deallocate(cgrid%fmean_vleaf_resp      )
       if(associated(cgrid%fmean_plresp          )) deallocate(cgrid%fmean_plresp          )
       if(associated(cgrid%fmean_leaf_energy     )) deallocate(cgrid%fmean_leaf_energy     )
       if(associated(cgrid%fmean_leaf_water      )) deallocate(cgrid%fmean_leaf_water      )
@@ -6760,7 +6731,6 @@ module ed_state_vars
       if(associated(cgrid%dmean_root_resp       )) deallocate(cgrid%dmean_root_resp       )
       if(associated(cgrid%dmean_growth_resp     )) deallocate(cgrid%dmean_growth_resp     )
       if(associated(cgrid%dmean_storage_resp    )) deallocate(cgrid%dmean_storage_resp    )
-      if(associated(cgrid%dmean_vleaf_resp      )) deallocate(cgrid%dmean_vleaf_resp      )
       if(associated(cgrid%dmean_plresp          )) deallocate(cgrid%dmean_plresp          )
       if(associated(cgrid%dmean_leaf_energy     )) deallocate(cgrid%dmean_leaf_energy     )
       if(associated(cgrid%dmean_leaf_water      )) deallocate(cgrid%dmean_leaf_water      )
@@ -6899,7 +6869,6 @@ module ed_state_vars
       if(associated(cgrid%mmean_root_resp       )) deallocate(cgrid%mmean_root_resp       )
       if(associated(cgrid%mmean_growth_resp     )) deallocate(cgrid%mmean_growth_resp     )
       if(associated(cgrid%mmean_storage_resp    )) deallocate(cgrid%mmean_storage_resp    )
-      if(associated(cgrid%mmean_vleaf_resp      )) deallocate(cgrid%mmean_vleaf_resp      )
       if(associated(cgrid%mmean_plresp          )) deallocate(cgrid%mmean_plresp          )
       if(associated(cgrid%mmean_leaf_energy     )) deallocate(cgrid%mmean_leaf_energy     )
       if(associated(cgrid%mmean_leaf_water      )) deallocate(cgrid%mmean_leaf_water      )
@@ -7056,7 +7025,6 @@ module ed_state_vars
       if(associated(cgrid%qmean_root_resp       )) deallocate(cgrid%qmean_root_resp       )
       if(associated(cgrid%qmean_growth_resp     )) deallocate(cgrid%qmean_growth_resp     )
       if(associated(cgrid%qmean_storage_resp    )) deallocate(cgrid%qmean_storage_resp    )
-      if(associated(cgrid%qmean_vleaf_resp      )) deallocate(cgrid%qmean_vleaf_resp      )
       if(associated(cgrid%qmean_plresp          )) deallocate(cgrid%qmean_plresp          )
       if(associated(cgrid%qmean_leaf_energy     )) deallocate(cgrid%qmean_leaf_energy     )
       if(associated(cgrid%qmean_leaf_water      )) deallocate(cgrid%qmean_leaf_water      )
@@ -7925,7 +7893,6 @@ module ed_state_vars
       if(associated(cpatch%today_nppdaily      )) deallocate(cpatch%today_nppdaily      )
       if(associated(cpatch%growth_respiration  )) deallocate(cpatch%growth_respiration  )
       if(associated(cpatch%storage_respiration )) deallocate(cpatch%storage_respiration )
-      if(associated(cpatch%vleaf_respiration   )) deallocate(cpatch%vleaf_respiration   )
       if(associated(cpatch%monthly_dndt        )) deallocate(cpatch%monthly_dndt        )
       if(associated(cpatch%monthly_dlnndt      )) deallocate(cpatch%monthly_dlnndt      )
       if(associated(cpatch%mort_rate           )) deallocate(cpatch%mort_rate           )
@@ -7988,7 +7955,6 @@ module ed_state_vars
       if(associated(cpatch%fmean_root_resp     )) deallocate(cpatch%fmean_root_resp     )
       if(associated(cpatch%fmean_growth_resp   )) deallocate(cpatch%fmean_growth_resp   )
       if(associated(cpatch%fmean_storage_resp  )) deallocate(cpatch%fmean_storage_resp  )
-      if(associated(cpatch%fmean_vleaf_resp    )) deallocate(cpatch%fmean_vleaf_resp    )
       if(associated(cpatch%fmean_plresp        )) deallocate(cpatch%fmean_plresp        )
       if(associated(cpatch%fmean_leaf_energy   )) deallocate(cpatch%fmean_leaf_energy   )
       if(associated(cpatch%fmean_leaf_water    )) deallocate(cpatch%fmean_leaf_water    )
@@ -8053,7 +8019,6 @@ module ed_state_vars
       if(associated(cpatch%dmean_root_resp     )) deallocate(cpatch%dmean_root_resp     )
       if(associated(cpatch%dmean_growth_resp   )) deallocate(cpatch%dmean_growth_resp   )
       if(associated(cpatch%dmean_storage_resp  )) deallocate(cpatch%dmean_storage_resp  )
-      if(associated(cpatch%dmean_vleaf_resp    )) deallocate(cpatch%dmean_vleaf_resp    )
       if(associated(cpatch%dmean_plresp        )) deallocate(cpatch%dmean_plresp        )
       if(associated(cpatch%dmean_leaf_energy   )) deallocate(cpatch%dmean_leaf_energy   )
       if(associated(cpatch%dmean_leaf_water    )) deallocate(cpatch%dmean_leaf_water    )
@@ -8122,7 +8087,6 @@ module ed_state_vars
       if(associated(cpatch%mmean_root_resp     )) deallocate(cpatch%mmean_root_resp     )
       if(associated(cpatch%mmean_growth_resp   )) deallocate(cpatch%mmean_growth_resp   )
       if(associated(cpatch%mmean_storage_resp  )) deallocate(cpatch%mmean_storage_resp  )
-      if(associated(cpatch%mmean_vleaf_resp    )) deallocate(cpatch%mmean_vleaf_resp    )
       if(associated(cpatch%mmean_plresp        )) deallocate(cpatch%mmean_plresp        )
       if(associated(cpatch%mmean_leaf_energy   )) deallocate(cpatch%mmean_leaf_energy   )
       if(associated(cpatch%mmean_leaf_water    )) deallocate(cpatch%mmean_leaf_water    )
@@ -8195,7 +8159,6 @@ module ed_state_vars
       if(associated(cpatch%qmean_root_resp     )) deallocate(cpatch%qmean_root_resp     )
       if(associated(cpatch%qmean_growth_resp   )) deallocate(cpatch%qmean_growth_resp   )
       if(associated(cpatch%qmean_storage_resp  )) deallocate(cpatch%qmean_storage_resp  )
-      if(associated(cpatch%qmean_vleaf_resp    )) deallocate(cpatch%qmean_vleaf_resp    )
       if(associated(cpatch%qmean_plresp        )) deallocate(cpatch%qmean_plresp        )
       if(associated(cpatch%qmean_leaf_energy   )) deallocate(cpatch%qmean_leaf_energy   )
       if(associated(cpatch%qmean_leaf_water    )) deallocate(cpatch%qmean_leaf_water    )
@@ -9722,7 +9685,6 @@ module ed_state_vars
          opatch%today_nppdaily        (oco) = ipatch%today_nppdaily        (ico)
          opatch%growth_respiration    (oco) = ipatch%growth_respiration    (ico)
          opatch%storage_respiration   (oco) = ipatch%storage_respiration   (ico)
-         opatch%vleaf_respiration     (oco) = ipatch%vleaf_respiration     (ico)
          opatch%monthly_dndt          (oco) = ipatch%monthly_dndt          (ico)
          opatch%monthly_dlnndt        (oco) = ipatch%monthly_dlnndt        (ico)
          opatch%krdepth               (oco) = ipatch%krdepth               (ico)
@@ -9783,7 +9745,6 @@ module ed_state_vars
          opatch%fmean_root_resp       (oco) = ipatch%fmean_root_resp       (ico)
          opatch%fmean_growth_resp     (oco) = ipatch%fmean_growth_resp     (ico)
          opatch%fmean_storage_resp    (oco) = ipatch%fmean_storage_resp    (ico)
-         opatch%fmean_vleaf_resp      (oco) = ipatch%fmean_vleaf_resp      (ico)
          opatch%fmean_plresp          (oco) = ipatch%fmean_plresp          (ico)
          opatch%fmean_leaf_energy     (oco) = ipatch%fmean_leaf_energy     (ico)
          opatch%fmean_leaf_water      (oco) = ipatch%fmean_leaf_water      (ico)
@@ -9879,7 +9840,6 @@ module ed_state_vars
             opatch%dmean_root_resp       (oco) = ipatch%dmean_root_resp       (ico)
             opatch%dmean_growth_resp     (oco) = ipatch%dmean_growth_resp     (ico)
             opatch%dmean_storage_resp    (oco) = ipatch%dmean_storage_resp    (ico)
-            opatch%dmean_vleaf_resp      (oco) = ipatch%dmean_vleaf_resp      (ico)
             opatch%dmean_plresp          (oco) = ipatch%dmean_plresp          (ico)
             opatch%dmean_leaf_energy     (oco) = ipatch%dmean_leaf_energy     (ico)
             opatch%dmean_leaf_water      (oco) = ipatch%dmean_leaf_water      (ico)
@@ -9960,7 +9920,6 @@ module ed_state_vars
             opatch%mmean_root_resp       (oco) = ipatch%mmean_root_resp       (ico)
             opatch%mmean_growth_resp     (oco) = ipatch%mmean_growth_resp     (ico)
             opatch%mmean_storage_resp    (oco) = ipatch%mmean_storage_resp    (ico)
-            opatch%mmean_vleaf_resp      (oco) = ipatch%mmean_vleaf_resp      (ico)
             opatch%mmean_plresp          (oco) = ipatch%mmean_plresp          (ico)
             opatch%mmean_leaf_energy     (oco) = ipatch%mmean_leaf_energy     (ico)
             opatch%mmean_leaf_water      (oco) = ipatch%mmean_leaf_water      (ico)
@@ -10052,7 +10011,6 @@ module ed_state_vars
                opatch%qmean_root_resp       (n,oco) = ipatch%qmean_root_resp       (n,ico)
                opatch%qmean_growth_resp     (n,oco) = ipatch%qmean_growth_resp     (n,ico)
                opatch%qmean_storage_resp    (n,oco) = ipatch%qmean_storage_resp    (n,ico)
-               opatch%qmean_vleaf_resp      (n,oco) = ipatch%qmean_vleaf_resp      (n,ico)
                opatch%qmean_plresp          (n,oco) = ipatch%qmean_plresp          (n,ico)
                opatch%qmean_leaf_energy     (n,oco) = ipatch%qmean_leaf_energy     (n,ico)
                opatch%qmean_leaf_water      (n,oco) = ipatch%qmean_leaf_water      (n,ico)
@@ -10289,7 +10247,6 @@ module ed_state_vars
       opatch%today_nppdaily        (1:z) = pack(ipatch%today_nppdaily            ,lmask)
       opatch%growth_respiration    (1:z) = pack(ipatch%growth_respiration        ,lmask)
       opatch%storage_respiration   (1:z) = pack(ipatch%storage_respiration       ,lmask)
-      opatch%vleaf_respiration     (1:z) = pack(ipatch%vleaf_respiration         ,lmask)
       opatch%monthly_dndt          (1:z) = pack(ipatch%monthly_dndt              ,lmask)
       opatch%monthly_dlnndt        (1:z) = pack(ipatch%monthly_dlnndt            ,lmask)
       opatch%krdepth               (1:z) = pack(ipatch%krdepth                   ,lmask)
@@ -10407,7 +10364,6 @@ module ed_state_vars
       opatch%fmean_root_resp       (1:z) = pack(ipatch%fmean_root_resp           ,lmask)
       opatch%fmean_growth_resp     (1:z) = pack(ipatch%fmean_growth_resp         ,lmask)
       opatch%fmean_storage_resp    (1:z) = pack(ipatch%fmean_storage_resp        ,lmask)
-      opatch%fmean_vleaf_resp      (1:z) = pack(ipatch%fmean_vleaf_resp          ,lmask)
       opatch%fmean_plresp          (1:z) = pack(ipatch%fmean_plresp              ,lmask)
       opatch%fmean_leaf_energy     (1:z) = pack(ipatch%fmean_leaf_energy         ,lmask)
       opatch%fmean_leaf_water      (1:z) = pack(ipatch%fmean_leaf_water          ,lmask)
@@ -10510,7 +10466,6 @@ module ed_state_vars
       opatch%dmean_root_resp       (1:z) = pack(ipatch%dmean_root_resp           ,lmask)
       opatch%dmean_growth_resp     (1:z) = pack(ipatch%dmean_growth_resp         ,lmask)
       opatch%dmean_storage_resp    (1:z) = pack(ipatch%dmean_storage_resp        ,lmask)
-      opatch%dmean_vleaf_resp      (1:z) = pack(ipatch%dmean_vleaf_resp          ,lmask)
       opatch%dmean_plresp          (1:z) = pack(ipatch%dmean_plresp              ,lmask)
       opatch%dmean_leaf_energy     (1:z) = pack(ipatch%dmean_leaf_energy         ,lmask)
       opatch%dmean_leaf_water      (1:z) = pack(ipatch%dmean_leaf_water          ,lmask)
@@ -10614,7 +10569,6 @@ module ed_state_vars
       opatch%mmean_root_resp       (1:z) = pack(ipatch%mmean_root_resp           ,lmask)
       opatch%mmean_growth_resp     (1:z) = pack(ipatch%mmean_growth_resp         ,lmask)
       opatch%mmean_storage_resp    (1:z) = pack(ipatch%mmean_storage_resp        ,lmask)
-      opatch%mmean_vleaf_resp      (1:z) = pack(ipatch%mmean_vleaf_resp          ,lmask)
       opatch%mmean_plresp          (1:z) = pack(ipatch%mmean_plresp              ,lmask)
       opatch%mmean_leaf_energy     (1:z) = pack(ipatch%mmean_leaf_energy         ,lmask)
       opatch%mmean_leaf_water      (1:z) = pack(ipatch%mmean_leaf_water          ,lmask)
@@ -10732,7 +10686,6 @@ module ed_state_vars
          opatch%qmean_root_resp     (n,1:z) = pack(ipatch%qmean_root_resp     (n,:),lmask)
          opatch%qmean_growth_resp   (n,1:z) = pack(ipatch%qmean_growth_resp   (n,:),lmask)
          opatch%qmean_storage_resp  (n,1:z) = pack(ipatch%qmean_storage_resp  (n,:),lmask)
-         opatch%qmean_vleaf_resp    (n,1:z) = pack(ipatch%qmean_vleaf_resp    (n,:),lmask)
          opatch%qmean_plresp        (n,1:z) = pack(ipatch%qmean_plresp        (n,:),lmask)
          opatch%qmean_leaf_energy   (n,1:z) = pack(ipatch%qmean_leaf_energy   (n,:),lmask)
          opatch%qmean_leaf_water    (n,1:z) = pack(ipatch%qmean_leaf_water    (n,:),lmask)
@@ -12101,15 +12054,6 @@ module ed_state_vars
                            ,'Sub-daily mean - Storage respiration'                         &
                            ,'[  kgC/m2/yr]','(ipoly)'            )
       end if
-      if (associated(cgrid%fmean_vleaf_resp      )) then
-         nvar = nvar+1
-         call vtable_edio_r(npts,cgrid%fmean_vleaf_resp                                    &
-                           ,nvar,igr,init,cgrid%pyglob_id,var_len,var_len_global,max_ptrs  &
-                           ,'FMEAN_VLEAF_RESP_PY        :11:'//trim(fast_keys)     )
-         call metadata_edio(nvar,igr                                                       &
-                           ,'Sub-daily mean - Virtual leaf respiration'                    &
-                           ,'[  kgC/m2/yr]','(ipoly)'            )
-      end if
       if (associated(cgrid%fmean_plresp          )) then
          nvar = nvar+1
          call vtable_edio_r(npts,cgrid%fmean_plresp                                        &
@@ -13301,15 +13245,6 @@ module ed_state_vars
                            ,'Daily mean - Storage respiration'                             &
                            ,'[  kgC/m2/yr]','(ipoly)'            )
       end if
-      if (associated(cgrid%dmean_vleaf_resp      )) then
-         nvar = nvar+1
-         call vtable_edio_r(npts,cgrid%dmean_vleaf_resp                                    &
-                           ,nvar,igr,init,cgrid%pyglob_id,var_len,var_len_global,max_ptrs  &
-                           ,'DMEAN_VLEAF_RESP_PY        :11:'//trim(dail_keys)     )
-         call metadata_edio(nvar,igr                                                       &
-                           ,'Daily mean - Virtual leaf respiration'                        &
-                           ,'[  kgC/m2/yr]','(ipoly)'            )
-      end if
       if (associated(cgrid%dmean_plresp          )) then
          nvar = nvar+1
          call vtable_edio_r(npts,cgrid%dmean_plresp                                        &
@@ -14373,15 +14308,6 @@ module ed_state_vars
                            ,'MMEAN_STORAGE_RESP_PY      :11:'//trim(eorq_keys))
          call metadata_edio(nvar,igr                                                       &
                            ,'Monthly mean - Storage respiration'                           &
-                           ,'[  kgC/m2/yr]','(ipoly)'            )
-      end if
-      if (associated(cgrid%mmean_vleaf_resp      )) then
-         nvar = nvar+1
-         call vtable_edio_r(npts,cgrid%mmean_vleaf_resp                                    &
-                           ,nvar,igr,init,cgrid%pyglob_id,var_len,var_len_global,max_ptrs  &
-                           ,'MMEAN_VLEAF_RESP_PY        :11:'//trim(eorq_keys))
-         call metadata_edio(nvar,igr                                                       &
-                           ,'Monthly mean - Virtual leaf respiration'                      &
                            ,'[  kgC/m2/yr]','(ipoly)'            )
       end if
       if (associated(cgrid%mmean_plresp          )) then
@@ -15832,15 +15758,6 @@ module ed_state_vars
                            ,'QMEAN_STORAGE_RESP_PY     :-11:'//trim(eorq_keys)     )
          call metadata_edio(nvar,igr                                                       &
                            ,'Mean diel - Storage respiration'                              &
-                           ,'[  kgC/m2/yr]','(ndcycle,ipoly)'    )
-      end if
-      if (associated(cgrid%qmean_vleaf_resp      )) then
-         nvar = nvar+1
-         call vtable_edio_r(npts,cgrid%qmean_vleaf_resp                                    &
-                           ,nvar,igr,init,cgrid%pyglob_id,var_len,var_len_global,max_ptrs  &
-                           ,'QMEAN_VLEAF_RESP_PY       :-11:'//trim(eorq_keys)     )
-         call metadata_edio(nvar,igr                                                       &
-                           ,'Mean diel - Virtual leaf respiration'                         &
                            ,'[  kgC/m2/yr]','(ndcycle,ipoly)'    )
       end if
       if (associated(cgrid%qmean_plresp          )) then
@@ -24355,13 +24272,6 @@ module ed_state_vars
          call metadata_edio(nvar,igr,'No metadata available','[NA]','NA') 
       end if
 
-      if (associated(cpatch%vleaf_respiration)) then
-         nvar=nvar+1
-           call vtable_edio_r(npts,cpatch%vleaf_respiration,nvar,igr,init,cpatch%coglob_id, &
-           var_len,var_len_global,max_ptrs,'VLEAF_RESPIRATION :41:hist:anal') 
-         call metadata_edio(nvar,igr,'No metadata available','[NA]','NA') 
-      end if  
-
       if (associated(cpatch%monthly_dndt)) then
          nvar=nvar+1
            call vtable_edio_r(npts,cpatch%monthly_dndt,nvar,igr,init,cpatch%coglob_id, &
@@ -24827,15 +24737,6 @@ module ed_state_vars
                            ,'FMEAN_STORAGE_RESP_CO      :41:'//trim(fast_keys)     )
          call metadata_edio(nvar,igr                                                       &
                            ,'Sub-daily mean - Storage respiration'                         &
-                           ,'[  kgC/m2/yr]','(icohort)'            )
-      end if
-      if (associated(cpatch%fmean_vleaf_resp      )) then
-         nvar = nvar+1
-         call vtable_edio_r(npts,cpatch%fmean_vleaf_resp                                   &
-                           ,nvar,igr,init,cpatch%coglob_id,var_len,var_len_global,max_ptrs &
-                           ,'FMEAN_VLEAF_RESP_CO        :41:'//trim(fast_keys)     )
-         call metadata_edio(nvar,igr                                                       &
-                           ,'Sub-daily mean - Virtual leaf respiration'                    &
                            ,'[  kgC/m2/yr]','(icohort)'            )
       end if
       if (associated(cpatch%fmean_plresp          )) then
@@ -25437,15 +25338,6 @@ module ed_state_vars
                            ,'Daily mean - Storage respiration'                             &
                            ,'[  kgC/m2/yr]','(icohort)'            )
       end if
-      if (associated(cpatch%dmean_vleaf_resp      )) then
-         nvar = nvar+1
-         call vtable_edio_r(npts,cpatch%dmean_vleaf_resp                                   &
-                           ,nvar,igr,init,cpatch%coglob_id,var_len,var_len_global,max_ptrs &
-                           ,'DMEAN_VLEAF_RESP_CO        :41:'//trim(dail_keys)     )
-         call metadata_edio(nvar,igr                                                       &
-                           ,'Daily mean - Virtual leaf respiration'                        &
-                           ,'[  kgC/m2/yr]','(icohort)'            )
-      end if
       if (associated(cpatch%dmean_plresp          )) then
          nvar = nvar+1
          call vtable_edio_r(npts,cpatch%dmean_plresp                                       &
@@ -25985,15 +25877,6 @@ module ed_state_vars
                            ,'MMEAN_STORAGE_RESP_CO      :41:'//trim(eorq_keys))
          call metadata_edio(nvar,igr                                                       &
                            ,'Monthly mean - Storage respiration'                           &
-                           ,'[  kgC/m2/yr]','(icohort)'            )
-      end if
-      if (associated(cpatch%mmean_vleaf_resp      )) then
-         nvar = nvar+1
-         call vtable_edio_r(npts,cpatch%mmean_vleaf_resp                                   &
-                           ,nvar,igr,init,cpatch%coglob_id,var_len,var_len_global,max_ptrs &
-                           ,'MMEAN_VLEAF_RESP_CO        :41:'//trim(eorq_keys))
-         call metadata_edio(nvar,igr                                                       &
-                           ,'Monthly mean - Virtual leaf respiration'                      &
                            ,'[  kgC/m2/yr]','(icohort)'            )
       end if
       if (associated(cpatch%mmean_plresp          )) then
@@ -26738,15 +26621,6 @@ module ed_state_vars
                            ,'QMEAN_STORAGE_RESP_CO     :-41:'//trim(eorq_keys)     )
          call metadata_edio(nvar,igr                                                       &
                            ,'Mean diel - Storage respiration'                              &
-                           ,'[  kgC/m2/yr]','(ndcycle,icohort)'    )
-      end if
-      if (associated(cpatch%qmean_vleaf_resp      )) then
-         nvar = nvar+1
-         call vtable_edio_r(npts,cpatch%qmean_vleaf_resp                                   &
-                           ,nvar,igr,init,cpatch%coglob_id,var_len,var_len_global,max_ptrs &
-                           ,'QMEAN_VLEAF_RESP_CO       :-41:'//trim(eorq_keys)     )
-         call metadata_edio(nvar,igr                                                       &
-                           ,'Mean diel - Virtual leaf respiration'                         &
                            ,'[  kgC/m2/yr]','(ndcycle,icohort)'    )
       end if
       if (associated(cpatch%qmean_plresp          )) then

--- a/ED/src/memory/rk4_coms.f90
+++ b/ED/src/memory/rk4_coms.f90
@@ -224,7 +224,6 @@ module rk4_coms
       real(kind=8), pointer, dimension(:) :: root_resp    ! Root respiration    [µmol/m²/s]
       real(kind=8), pointer, dimension(:) :: growth_resp  ! Growth respiration  [µmol/m²/s]
       real(kind=8), pointer, dimension(:) :: storage_resp ! Storage respiration [µmol/m²/s]
-      real(kind=8), pointer, dimension(:) :: vleaf_resp   ! Virtual leaf resp.  [µmol/m²/s]
 
 
       !------ Variables used for hybrid stepping -----------------------------------------!
@@ -1246,7 +1245,6 @@ module rk4_coms
       allocate(y%root_resp        (maxcohort))
       allocate(y%growth_resp      (maxcohort))
       allocate(y%storage_resp     (maxcohort))
-      allocate(y%vleaf_resp       (maxcohort))
 
       allocate(y%wflxlc           (maxcohort))
       allocate(y%wflxwc           (maxcohort))
@@ -1345,7 +1343,6 @@ module rk4_coms
       nullify(y%root_resp        )
       nullify(y%growth_resp      )
       nullify(y%storage_resp     )
-      nullify(y%vleaf_resp       )
 
       nullify(y%wflxlc           )
       nullify(y%wflxwc           )
@@ -1443,7 +1440,6 @@ module rk4_coms
       if (associated(y%root_resp        )) y%root_resp        = 0.d0
       if (associated(y%growth_resp      )) y%growth_resp      = 0.d0
       if (associated(y%storage_resp     )) y%storage_resp     = 0.d0
-      if (associated(y%vleaf_resp       )) y%vleaf_resp       = 0.d0
 
       if (associated(y%wflxlc           )) y%wflxlc           = 0.d0
       if (associated(y%wflxwc           )) y%wflxwc           = 0.d0
@@ -1540,7 +1536,6 @@ module rk4_coms
       if (associated(y%root_resp        )) deallocate(y%root_resp         )
       if (associated(y%growth_resp      )) deallocate(y%growth_resp       )
       if (associated(y%storage_resp     )) deallocate(y%storage_resp      )
-      if (associated(y%vleaf_resp       )) deallocate(y%vleaf_resp        )
 
       if (associated(y%wflxlc           )) deallocate(y%wflxlc            )
       if (associated(y%wflxwc           )) deallocate(y%wflxwc            )

--- a/ED/src/utils/budget_utils.f90
+++ b/ED/src/utils/budget_utils.f90
@@ -108,7 +108,6 @@ module budget_utils
       real                                                    :: co2curr_rootresp
       real                                                    :: co2curr_growthresp
       real                                                    :: co2curr_storageresp
-      real                                                    :: co2curr_vleafresp
       real                                                    :: co2curr_hetresp
       real                                                    :: co2curr_nep
       real                                                    :: co2curr_denseffect
@@ -130,7 +129,6 @@ module budget_utils
       real                                                    :: root_resp
       real                                                    :: growth_resp
       real                                                    :: storage_resp
-      real                                                    :: vleaf_resp
       real                                                    :: co2_factor
       real                                                    :: ene_factor
       real                                                    :: h2o_factor
@@ -253,17 +251,15 @@ module budget_utils
       !     Compute the carbon flux components.                                            !
       !------------------------------------------------------------------------------------!
       call sum_plant_cfluxes(csite,ipa,gpp,leaf_resp,root_resp,growth_resp                 &
-                            ,storage_resp,vleaf_resp)
+                            ,storage_resp)
       co2curr_gpp         = gpp           * dtlsm
       co2curr_leafresp    = leaf_resp     * dtlsm
       co2curr_rootresp    = root_resp     * dtlsm
       co2curr_growthresp  = growth_resp   * dtlsm
       co2curr_storageresp = storage_resp  * dtlsm
-      co2curr_vleafresp   = vleaf_resp    * dtlsm
       co2curr_hetresp     = csite%rh(ipa) * dtlsm
       co2curr_nep         = co2curr_gpp - co2curr_leafresp - co2curr_rootresp              &
-                          - co2curr_growthresp - co2curr_storageresp - co2curr_vleafresp   &
-                          - co2curr_hetresp
+                          - co2curr_growthresp - co2curr_storageresp - co2curr_hetresp
       cbudget_nep         = cbudget_nep + site_area * csite%area(ipa) * co2curr_nep        &
                                         * umol_2_kgC
 
@@ -315,7 +311,7 @@ module budget_utils
       csite%co2budget_gpp(ipa)         = csite%co2budget_gpp(ipa)       + gpp       *dtlsm
       csite%co2budget_plresp(ipa)      = csite%co2budget_plresp(ipa)                       &
                                        + ( leaf_resp + root_resp + growth_resp             &
-                                         + storage_resp + vleaf_resp ) * dtlsm
+                                         + storage_resp) * dtlsm
       csite%co2budget_rh(ipa)          = csite%co2budget_rh(ipa)                           &
                                        + csite%rh(ipa) * dtlsm
       csite%co2budget_denseffect(ipa)  = csite%co2budget_denseffect(ipa)                   &
@@ -401,7 +397,6 @@ module budget_utils
             write (unit=*,fmt=fmtf ) ' ROOT_RESP      : ',co2curr_rootresp
             write (unit=*,fmt=fmtf ) ' GROWTH_RESP    : ',co2curr_growthresp
             write (unit=*,fmt=fmtf ) ' STORAGE_RESP   : ',co2curr_storageresp
-            write (unit=*,fmt=fmtf ) ' VLEAF_RESP     : ',co2curr_vleafresp
             write (unit=*,fmt=fmtf ) ' HET_RESP       : ',co2curr_hetresp
             write (unit=*,fmt=fmtf ) ' NEP            : ',co2curr_nep
             write (unit=*,fmt=fmtf ) ' DENSITY_EFFECT : ',co2curr_denseffect
@@ -719,7 +714,7 @@ module budget_utils
    !    This subroutine computes the carbon flux terms.                                    !
    !---------------------------------------------------------------------------------------!
    subroutine sum_plant_cfluxes(csite,ipa, gpp, leaf_resp,root_resp,growth_resp            &
-                               ,storage_resp,vleaf_resp)
+                               ,storage_resp)
       use ed_state_vars        , only : sitetype    & ! structure
                                       , patchtype   ! ! structure
       use consts_coms          , only : day_sec     & ! intent(in)
@@ -735,14 +730,11 @@ module budget_utils
       real                  , intent(out) :: root_resp
       real                  , intent(out) :: growth_resp
       real                  , intent(out) :: storage_resp
-      real                  , intent(out) :: vleaf_resp
       !----- Local variables --------------------------------------------------------------!
       type(patchtype), pointer            :: cpatch
       integer                             :: k
       integer                             :: ico
       integer                             :: idbh
-      real                                :: lrresp !  Leaf and root respiration
-      real                                :: sresp  !  Storage, growth, vleaf respiration.
       !------------------------------------------------------------------------------------!
 
       !----- Initializing some variables. -------------------------------------------------!
@@ -751,7 +743,6 @@ module budget_utils
       root_resp    = 0.0
       growth_resp  = 0.0
       storage_resp = 0.0
-      vleaf_resp   = 0.0
       cpatch => csite%patch(ipa)
 
       !------------------------------------------------------------------------------------!
@@ -776,9 +767,6 @@ module budget_utils
                       / (day_sec * umol_2_kgC)
          storage_resp = storage_resp                                                       &
                       + cpatch%storage_respiration(ico) * cpatch%nplant(ico)               &
-                      / (day_sec * umol_2_kgC)
-         vleaf_resp   = vleaf_resp                                                         &
-                      + cpatch%vleaf_respiration(ico)   * cpatch%nplant(ico)               &
                       / (day_sec * umol_2_kgC)
       end do
 

--- a/ED/src/utils/fuse_fiss_utils.f90
+++ b/ED/src/utils/fuse_fiss_utils.f90
@@ -1403,8 +1403,6 @@ module fuse_fiss_utils
                                        + cpatch%growth_respiration (donc) * dnplant
       cpatch%storage_respiration(recc) = cpatch%storage_respiration(recc) * rnplant        &
                                        + cpatch%storage_respiration(donc) * dnplant
-      cpatch%vleaf_respiration  (recc) = cpatch%vleaf_respiration  (recc) * rnplant        &
-                                       + cpatch%vleaf_respiration  (donc) * dnplant
       !------------------------------------------------------------------------------------!
 
 
@@ -1547,10 +1545,6 @@ module fuse_fiss_utils
          cpatch%fmean_storage_resp    (recc) = cpatch%fmean_storage_resp    (recc)         &
                                              * rnplant                                     &
                                              + cpatch%fmean_storage_resp    (donc)         &
-                                             * dnplant
-         cpatch%fmean_vleaf_resp      (recc) = cpatch%fmean_vleaf_resp      (recc)         &
-                                             * rnplant                                     &
-                                             + cpatch%fmean_vleaf_resp      (donc)         &
                                              * dnplant
          cpatch%fmean_plresp          (recc) = cpatch%fmean_plresp          (recc)         &
                                              * rnplant                                     &
@@ -1786,10 +1780,6 @@ module fuse_fiss_utils
          cpatch%dmean_storage_resp    (recc) = cpatch%dmean_storage_resp    (recc)         &
                                              * rnplant                                     &
                                              + cpatch%dmean_storage_resp    (donc)         &
-                                             * dnplant
-         cpatch%dmean_vleaf_resp      (recc) = cpatch%dmean_vleaf_resp      (recc)         &
-                                             * rnplant                                     &
-                                             + cpatch%dmean_vleaf_resp      (donc)         &
                                              * dnplant
          cpatch%dmean_plresp          (recc) = cpatch%dmean_plresp          (recc)         &
                                              * rnplant                                     &
@@ -2089,10 +2079,6 @@ module fuse_fiss_utils
          cpatch%mmean_storage_resp    (recc) = cpatch%mmean_storage_resp    (recc)         &
                                              * rnplant                                     &
                                              + cpatch%mmean_storage_resp    (donc)         &
-                                             * dnplant
-         cpatch%mmean_vleaf_resp      (recc) = cpatch%mmean_vleaf_resp      (recc)         &
-                                             * rnplant                                     &
-                                             + cpatch%mmean_vleaf_resp      (donc)         &
                                              * dnplant
          cpatch%mmean_plresp          (recc) = cpatch%mmean_plresp          (recc)         &
                                              * rnplant                                     &
@@ -2433,10 +2419,6 @@ module fuse_fiss_utils
          cpatch%qmean_storage_resp    (:,recc) = cpatch%qmean_storage_resp    (:,recc)     &
                                                * rnplant                                   &
                                                + cpatch%qmean_storage_resp    (:,donc)     &
-                                               * dnplant
-         cpatch%qmean_vleaf_resp      (:,recc) = cpatch%qmean_vleaf_resp      (:,recc)     &
-                                               * rnplant                                   &
-                                               + cpatch%qmean_vleaf_resp      (:,donc)     &
                                                * dnplant
          cpatch%qmean_plresp          (:,recc) = cpatch%qmean_plresp          (:,recc)     &
                                                * rnplant                                   &


### PR DESCRIPTION
Also, got rid of 2 unused local vars in budget_utils.f90.

Virtual leaf respiration is, as I understand it, vestigial junk in the representation of deciduous hardwood physiology. And as noted in issue #92, it comprises only a tiny fraction of respiration.

Here is the indication that it only affects pfts 9:11 (those with phenology scheme 2)...

From growth_balive.f90:
```fortran
                  !------------------------------------------------------------------------!
                  !     Find the "virtual" leaf respiration.                               !
                  !------------------------------------------------------------------------!
                  cpatch%vleaf_respiration(ico) = (1.0-cpoly%green_leaf_factor(ipft,isi))  &
                                                * salloci * cpatch%balive(ico)             &
                                                * storage_turnover_rate(ipft)              &
                                                * tfact * temp_dep
                  !------------------------------------------------------------------------!
```

From phenology_aux we can see the dependence of green_leaf_factor on phenology:
```fortran
   subroutine prescribed_leaf_state(...)
   ...
  (some stuff)
   ...
      !----- Load the values for each PFT. ------------------------------------------------!
      do pft = 1, n_pft
         select case (phenology(pft))
         case (2)
            green_leaf_factor(pft) = elongf
            leaf_aging_factor(pft) = delay
         case default
            green_leaf_factor(pft) = 1.0
            leaf_aging_factor(pft) = 1.0
         end select
      end do

      return
   end subroutine prescribed_leaf_state
```

and from ed_params.f90 we can see the dependence on the storage_turnover_rate:
```fortran
   storage_turnover_rate(1)       = onethird
   storage_turnover_rate(2)       = onesixth
   storage_turnover_rate(3)       = onesixth
   storage_turnover_rate(4)       = onesixth
   storage_turnover_rate(5)       = 0.00
   storage_turnover_rate(6)       = 0.00 ! 0.25
   storage_turnover_rate(7)       = 0.00 ! 0.25
   storage_turnover_rate(8)       = 0.00 ! 0.25
   storage_turnover_rate(9)       = 0.6243
   storage_turnover_rate(10)      = 0.6243
   storage_turnover_rate(11)      = 0.6243
   storage_turnover_rate(12)      = 0.00 ! 0.25
   storage_turnover_rate(13)      = 0.00 ! 0.25
   storage_turnover_rate(14)      = onethird
   storage_turnover_rate(15)      = onethird
   storage_turnover_rate(16)      = onethird
   storage_turnover_rate(17)      = onesixth
```

Given the above, #92 should accurately indicate the scope of the change. The changed files are easy enough to review. Should I push this through the test suite? Does anyone believe vleaf_respiration should be left in the model for some reason?
