### PR TITLE
Bug fix in reading history files

### DIFF
--- a/ED/src/io/ed_init_full_history.F90
+++ b/ED/src/io/ed_init_full_history.F90
@@ -5035,13 +5035,13 @@ subroutine fill_history_patch(cpatch,paco_index,ncohorts_global)
    call hdf_getslab_r(cpatch%today_nppdaily                                                &
                      ,'TODAY_NPPDAILY            ',dsetrank,iparallel,.true. ,foundvar)
    call hdf_getslab_r(cpatch%leaf_growth_resp                                              &
-                     ,'LEAF_GROWTH_RESPIRATION   ',dsetrank,iparallel,.true. ,foundvar)
+                     ,'LEAF_GROWTH_RESP   ',dsetrank,iparallel,.true. ,foundvar)
    call hdf_getslab_r(cpatch%root_growth_resp                                              &
-                     ,'ROOT_GROWTH_RESPIRATION   ',dsetrank,iparallel,.true. ,foundvar)
+                     ,'ROOT_GROWTH_RESP   ',dsetrank,iparallel,.true. ,foundvar)
    call hdf_getslab_r(cpatch%sapa_growth_resp                                              &
-                     ,'SAPA_GROWTH_RESPIRATION   ',dsetrank,iparallel,.true. ,foundvar)
+                     ,'SAPA_GROWTH_RESP   ',dsetrank,iparallel,.true. ,foundvar)
    call hdf_getslab_r(cpatch%sapb_growth_resp                                              &
-                     ,'SAPB_GROWTH_RESPIRATION   ',dsetrank,iparallel,.true. ,foundvar)
+                     ,'SAPB_GROWTH_RESP   ',dsetrank,iparallel,.true. ,foundvar)
    call hdf_getslab_r(cpatch%storage_respiration                                           &
                      ,'STORAGE_RESPIRATION       ',dsetrank,iparallel,.true. ,foundvar)
    call hdf_getslab_r(cpatch%monthly_dndt                                                  &


### PR DESCRIPTION
Few of the history file variables were named differentely than how they were read causing the model to crash. Fixed the bug.