### PR TITLE
correct cohort initialization

### DIFF
--- a/ED/src/init/ed_type_init.f90
+++ b/ED/src/init/ed_type_init.f90
@@ -294,7 +294,7 @@ subroutine init_ed_cohort_vars(cpatch,ico, lsl)
    cpatch%fmean_wshed_wg          (ico) = 0.0
 
    cpatch%fmean_lai               (ico) = 0.0
-   cpatch%bdead                   (ico) = 0.0
+   cpatch%fmean_bdead             (ico) = 0.0
    !---------------------------------------------------------------------------------------!
 
 


### PR DESCRIPTION
fix accidental zeroing of bdead instead of fmean_bdead in #88 (commit
f1bd1b72e47d3bf0adce8a076ae3be0864db8cd9)