### PR TITLE
fix fiss_fuse rules

### DIFF
--- a/ED/src/utils/fuse_fiss_utils.f90
+++ b/ED/src/utils/fuse_fiss_utils.f90
@@ -4641,6 +4641,7 @@ module fuse_fiss_utils
       !    Daily means.                                                                    !
       !------------------------------------------------------------------------------------! 
       if (writing_long .and.  (.not. fuse_initial) ) then
+        if ( all(csite%dmean_can_prss > 10.0) ) then
          csite%dmean_A_decomp           (recp) = ( csite%dmean_A_decomp           (recp)   &
                                                  * csite%area                     (recp)   &
                                                  + csite%dmean_A_decomp           (donp)   &
@@ -4962,6 +4963,7 @@ module fuse_fiss_utils
             csite%dmean_sfcw_fliq  (recp)  = csite%dmean_soil_fliq(mzg,recp)
          end if
          !------------------------------------------------------------------------------------!
+		end if
       end if
       !------------------------------------------------------------------------------------!
 
@@ -4969,6 +4971,7 @@ module fuse_fiss_utils
       !    Monthly means.                                                                  !
       !------------------------------------------------------------------------------------! 
       if (writing_eorq .and. (.not. fuse_initial)) then
+        if( all(csite%mmean_can_prss > 10.0) ) then
 
          !---------------------------------------------------------------------------------!
          !    First we find the mean sum of squares, because they depend on the means too, !
@@ -5442,6 +5445,7 @@ module fuse_fiss_utils
             csite%mmean_sfcw_fliq  (recp)  = csite%mmean_soil_fliq(mzg,recp)
          end if
          !------------------------------------------------------------------------------------!
+		end if
       end if
       !------------------------------------------------------------------------------------!
 
@@ -5452,6 +5456,7 @@ module fuse_fiss_utils
       !    Mean diel.                                                                      !
       !------------------------------------------------------------------------------------! 
       if (writing_dcyc .and. (.not. fuse_initial)) then
+        if( all(csite%qmean_can_prss > 10.0) ) then
          !---------------------------------------------------------------------------------!
          !      First we solve the mean sum of squares as they depend on the mean and the  !
          ! original receptor data is lost after fusion takes place.                        !
@@ -5871,6 +5876,7 @@ module fuse_fiss_utils
             !------------------------------------------------------------------------------!
          end do
          !---------------------------------------------------------------------------------!
+		end if
       end if
       !------------------------------------------------------------------------------------!
 


### PR DESCRIPTION
re-implement some fixes from @ryankelly-uiuc in #18 to keep fuse_fiss
from trying to evaluate non-existent values