### PR TITLE
Fixed xfer sign error mistake in cohorts with no carbon left.

### DIFF
--- a/ED/src/dynamics/growth_balive.f90
+++ b/ED/src/dynamics/growth_balive.f90
@@ -1217,7 +1217,7 @@ module growth_balive
                ! tissues.                                                                  !
                !---------------------------------------------------------------------------!
                carbon_debt = carbon_debt - cpatch%bstorage(ico)
-               tr_bstorage = cpatch%bstorage(ico)
+               tr_bstorage = -1.0*cpatch%bstorage(ico)
 
                !---------------------------------------------------------------------------!
                !     Find total biomass that can be lost.  We take an amount proportional  !
@@ -1240,8 +1240,8 @@ module growth_balive
                   ! cohort is going to fertilizer business.                                !
                   !------------------------------------------------------------------------!
                   carbon_debt = bloss_max
-                  tr_bleaf = cpatch%bleaf(ico);
-                  tr_broot = cpatch%broot(ico);
+                  tr_bleaf = -1.0*cpatch%bleaf(ico);
+                  tr_broot = -1.0*cpatch%broot(ico);
                   !------------------------------------------------------------------------!
                end if
                !---------------------------------------------------------------------------!
@@ -1267,8 +1267,8 @@ module growth_balive
                !     Not enough biomass, remove everything.                                !
                !---------------------------------------------------------------------------!
                carbon_debt = carbon_debt - bloss_max
-               tr_bleaf = cpatch%bleaf(ico);
-               tr_broot = cpatch%broot(ico);
+               tr_bleaf = -1.0*cpatch%bleaf(ico);
+               tr_broot = -1.0*cpatch%broot(ico);
                !---------------------------------------------------------------------------!
                
                !---------------------------------------------------------------------------!
@@ -1287,7 +1287,7 @@ module growth_balive
                   ! can't afford.  It is with profound sadness that we announce that this  !
                   ! cohort is going to fertilizer business.                                !
                   !------------------------------------------------------------------------!
-                  tr_bstorage = cpatch%bstorage(ico)
+                  tr_bstorage = -1.0*cpatch%bstorage(ico)
                   !------------------------------------------------------------------------!
                end if
             end if


### PR DESCRIPTION
Dying cohorts were given extra chances at life... I would say I'm sorry, but... 
Ok, I'm sorry, we need to get rid of them.

Note the tr_[pool] variables are added into their respective pools, hence the sign issue.