### PR TITLE
Update include.mk.opt.macosx

### DIFF
--- a/ED/build/bin/include.mk.opt.macosx
+++ b/ED/build/bin/include.mk.opt.macosx
@@ -144,9 +144,10 @@ PAR_DEFS=-DRAMS_MPI
 #-----------------------------------------------------------------
 
 # For IBM,HP,SGI,ALPHA,LINUX use these:
-ARCHIVE=ar rs
+#ARCHIVE=ar rs
 # For NEC SX-6
 #ARCHIVE=sxar rs
 # For SUN,CONVEX
 #ARCHIVE=ar r'
-
+# For Mac
+ARCHIVE=libtool -c -static -o


### PR DESCRIPTION
In Mac (or at least from OS X version 10.9) the archive utility does not include common symbols when building a library. As a consequence ar produce a library with undefined symbols (failing to link properly), for example this is the first of many errors

Undefined symbols for architecture x86_64:
  "_decomp_coms_mp_cwd_frac_", referenced from:
      _init_decomp_params_ in ed_2.1-opt.a(ed_params.o)

Indeed decomp_coms.o contains some common symbols that are not added to the ed_2.1-opt.a archive.
