### PR TITLE
Dealing with issue #144, making sure biomass aims are always defined, and updating EDTS ED2INs

### DIFF
--- a/ED/src/dynamics/growth_balive.f90
+++ b/ED/src/dynamics/growth_balive.f90
@@ -1102,6 +1102,17 @@ module growth_balive
                          ( available_carbon > 0.0 .and. cpatch%phenology_status(ico) == 1 )
       !------------------------------------------------------------------------------------!
 
+      !------------------------------------------------------------------------------------!
+      !     Maximum bleaf that the allometric relationship would allow.  If the plant is   !
+      ! drought stressed (elongf < 1), we don't allow it to get back to full allometry.    !
+      !------------------------------------------------------------------------------------!
+      bleaf_max      = size2bl(cpatch%dbh(ico),cpatch%hite(ico),ipft)
+      bleaf_aim      = bleaf_max * green_leaf_factor * cpatch%elongf(ico)
+      broot_aim      = bleaf_aim * q(ipft)
+      bsapwooda_aim  = bleaf_aim * qsw(ipft) * cpatch%hite(ico) * agf_bs(ipft)
+      bsapwoodb_aim  = bleaf_aim * qsw(ipft) * cpatch%hite(ico) * (1. - agf_bs(ipft))
+      balive_aim     = bleaf_aim + broot_aim + bsapwooda_aim + bsapwoodb_aim
+      !------------------------------------------------------------------------------------!
 
 
       !------------------------------------------------------------------------------------!
@@ -1118,17 +1129,6 @@ module growth_balive
             ! pools, and put any excess in storage.                                        !
             !------------------------------------------------------------------------------!
 
-            !------------------------------------------------------------------------------!
-            !     Maximum bleaf that the allometric relationship would allow.  If the      !
-            ! plant is drought stress (elongf < 1), we do not allow the plant to get back  !
-            ! to full allometry.                                                           !
-            !------------------------------------------------------------------------------!
-            bleaf_max      = size2bl(cpatch%dbh(ico),cpatch%hite(ico),ipft)
-            bleaf_aim      = bleaf_max * green_leaf_factor * cpatch%elongf(ico)
-            broot_aim      = bleaf_aim * q(ipft)
-            bsapwooda_aim  = bleaf_aim * qsw(ipft) * cpatch%hite(ico) * agf_bs(ipft)
-            bsapwoodb_aim  = bleaf_aim * qsw(ipft) * cpatch%hite(ico) * (1. - agf_bs(ipft))
-            balive_aim     = bleaf_aim + broot_aim + bsapwooda_aim + bsapwoodb_aim
             !---- Amount that bleaf, broot, and bsapwood are off allometry. ---------------!
             delta_bleaf     = max (0.0, bleaf_aim     - cpatch%bleaf    (ico))
             delta_broot     = max (0.0, broot_aim     - cpatch%broot    (ico))

--- a/ED/src/dynamics/growth_balive.f90
+++ b/ED/src/dynamics/growth_balive.f90
@@ -1890,7 +1890,7 @@ module growth_balive
             !------------------------------------------------------------------------------!
             !     Check whether we are on allometry or not.                                !
             !------------------------------------------------------------------------------!
-            on_allometry = (balive_aim - cpatch%balive(ico))/balive_aim < 0.000001
+            on_allometry = (balive_aim - cpatch%balive(ico)) <= 0.000001*balive_aim
             if (cpatch%elongf(ico) == 1.0 .and. on_allometry) then
                !---------------------------------------------------------------------------!
                !     We're back to allometry, change phenology_status.                     !

--- a/ED/src/dynamics/growth_balive.f90
+++ b/ED/src/dynamics/growth_balive.f90
@@ -241,7 +241,7 @@ module growth_balive
                      !---------------------------------------------------------------------!
                      !     Update the phenology status.                                    !
                      !---------------------------------------------------------------------!
-                     on_allometry = (balive_aim - cpatch%balive(ico))/balive_aim < 0.000001
+                     on_allometry = balive_aim - cpatch%balive(ico) <= 0.000001*balive_aim
                      if (flushing .and. cpatch%elongf(ico) == 1.0 .and. on_allometry) then
                         cpatch%phenology_status(ico) = 0
                      elseif(cpatch%bleaf(ico) < tiny_num .and.                             &

--- a/EDTS/Templates/ED2IN-ATA-DBUG
+++ b/EDTS/Templates/ED2IN-ATA-DBUG
@@ -1480,6 +1480,35 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-ATA-MAIN
+++ b/EDTS/Templates/ED2IN-ATA-MAIN
@@ -1478,6 +1478,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-ATA-TEST
+++ b/EDTS/Templates/ED2IN-ATA-TEST
@@ -1478,6 +1478,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-CAX-DBUG
+++ b/EDTS/Templates/ED2IN-CAX-DBUG
@@ -1488,6 +1488,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-CAX-MAIN
+++ b/EDTS/Templates/ED2IN-CAX-MAIN
@@ -1486,6 +1486,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-CAX-TEST
+++ b/EDTS/Templates/ED2IN-CAX-TEST
@@ -1487,6 +1487,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-HAR-DBUG
+++ b/EDTS/Templates/ED2IN-HAR-DBUG
@@ -1484,6 +1484,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
       NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 
 $END
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-HAR-MAIN
+++ b/EDTS/Templates/ED2IN-HAR-MAIN
@@ -1483,6 +1483,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
       NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
 
 $END
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-HAR-TEST
+++ b/EDTS/Templates/ED2IN-HAR-TEST
@@ -1484,6 +1484,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
       NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 
 $END
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-HIM-DBUG
+++ b/EDTS/Templates/ED2IN-HIM-DBUG
@@ -1470,6 +1470,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-HIM-MAIN
+++ b/EDTS/Templates/ED2IN-HIM-MAIN
@@ -1469,6 +1469,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-HIM-TEST
+++ b/EDTS/Templates/ED2IN-HIM-TEST
@@ -1470,6 +1470,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-HIP-DBUG
+++ b/EDTS/Templates/ED2IN-HIP-DBUG
@@ -1464,6 +1464,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-HIP-MAIN
+++ b/EDTS/Templates/ED2IN-HIP-MAIN
@@ -1462,6 +1462,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-HIP-TEST
+++ b/EDTS/Templates/ED2IN-HIP-TEST
@@ -1462,6 +1462,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-M34-DBUG
+++ b/EDTS/Templates/ED2IN-M34-DBUG
@@ -1472,6 +1472,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-M34-MAIN
+++ b/EDTS/Templates/ED2IN-M34-MAIN
@@ -1471,6 +1471,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-M34-TEST
+++ b/EDTS/Templates/ED2IN-M34-TEST
@@ -1472,6 +1472,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-PDG-DBUG
+++ b/EDTS/Templates/ED2IN-PDG-DBUG
@@ -1469,6 +1469,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-PDG-MAIN
+++ b/EDTS/Templates/ED2IN-PDG-MAIN
@@ -1470,6 +1470,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-PDG-TEST
+++ b/EDTS/Templates/ED2IN-PDG-TEST
@@ -1471,6 +1471,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-PET-DBUG
+++ b/EDTS/Templates/ED2IN-PET-DBUG
@@ -1542,6 +1542,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-PET-MAIN
+++ b/EDTS/Templates/ED2IN-PET-MAIN
@@ -1574,6 +1574,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-PET-TEST
+++ b/EDTS/Templates/ED2IN-PET-TEST
@@ -1546,6 +1546,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-RJG-DBUG
+++ b/EDTS/Templates/ED2IN-RJG-DBUG
@@ -1476,6 +1476,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-RJG-MAIN
+++ b/EDTS/Templates/ED2IN-RJG-MAIN
@@ -1475,6 +1475,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-RJG-TEST
+++ b/EDTS/Templates/ED2IN-RJG-TEST
@@ -1476,6 +1476,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-S67-DBUG
+++ b/EDTS/Templates/ED2IN-S67-DBUG
@@ -1477,6 +1477,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-S67-MAIN
+++ b/EDTS/Templates/ED2IN-S67-MAIN
@@ -1476,6 +1476,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-S67-TEST
+++ b/EDTS/Templates/ED2IN-S67-TEST
@@ -1477,6 +1477,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-TL2-MAIN
+++ b/EDTS/Templates/ED2IN-TL2-MAIN
@@ -1487,6 +1487,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
       NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 
 $END
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-TL2-TEST
+++ b/EDTS/Templates/ED2IN-TL2-TEST
@@ -1487,6 +1487,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
       NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 
 $END
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-TNF-DBUG
+++ b/EDTS/Templates/ED2IN-TNF-DBUG
@@ -1469,6 +1469,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-TNF-MAIN
+++ b/EDTS/Templates/ED2IN-TNF-MAIN
@@ -1469,6 +1469,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-TNF-TEST
+++ b/EDTS/Templates/ED2IN-TNF-TEST
@@ -1469,6 +1469,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-TON-DBUG
+++ b/EDTS/Templates/ED2IN-TON-DBUG
@@ -1469,6 +1469,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-TON-MAIN
+++ b/EDTS/Templates/ED2IN-TON-MAIN
@@ -1468,6 +1468,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!

--- a/EDTS/Templates/ED2IN-TON-TEST
+++ b/EDTS/Templates/ED2IN-TON-TEST
@@ -1469,6 +1469,31 @@ $ED_NL
    !---------------------------------------------------------------------------------------!
    NL%IOPTINPT = ''
    !---------------------------------------------------------------------------------------!
+   !---------------------------------------------------------------------------------------!
+   ! GROWTH_RESP_SCHEME -- This flag indicates how growth respiration fluxes are treated.  !
+   !                                                                                       !
+   !        0 - ED Default. Growth respiration is treated as tax on GPP, at pft-specific   !
+   !            rate given by growth_resp_factor. All growth respiration is treated as     !
+   !            aboveground wood -> canopy-airspace flux.                                  !
+   !        1 - Growth respiration is calculated as in 0, but split into fluxes entering   !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass. This does not affect carbon budget at all, it provides greater    !
+   !            within-ecosystem flux resolution.                                          !
+   !---------------------------------------------------------------------------------------!
+   NL%GROWTH_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
+
+
+   !---------------------------------------------------------------------------------------!
+   ! STORAGE_RESP_SCHEME -- This flag controls how storage respiration fluxes are treated. !
+   !                                                                                       !
+   !        0 - ED Default. Storage resp. is aboveground wood -> canopy-airspace flux.     !
+   !        1 - Storage respiration is calculated as in 0, but split into fluxes entering  !
+   !            the CAS from leaf, sapwooda, sapwoodb, and root sources, proportionally to !
+   !            biomass.                                                                   !
+   !---------------------------------------------------------------------------------------!
+   NL%STORAGE_RESP_SCHEME = 1
+   !---------------------------------------------------------------------------------------!
 $END
 !==========================================================================================!
 !==========================================================================================!


### PR DESCRIPTION
Test suite output is attached, Tonzi didn't complete for either the mainline or the test, but I've never been able to run Tonzi. I always get this fatal error:

```
+  Showing first 10 files:
 50    [-] File #:      1 edts_datasets/inits/kz_tonzi/test_ton-S-1912-02-01-000000-g01.h5
 51 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 52 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 53 ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 54
 55 --------------------------------------------------------------
 56                      !!! FATAL ERROR !!!
 57 --------------------------------------------------------------
 58     ---> File:        ed_state_vars.f90
 59     ---> Subroutine:  allocate_sitetype
 60     ---> Reason:      Attempt to set a site with 0 patches. This cannot happen!
 61 --------------------------------------------------------------
 62  ED execution halts (see previous error message)...
 63 --------------------------------------------------------------
 ```

But everything else looks good.

[8757397-dns-9ccb09b-v1_rapid.pdf](https://github.com/EDmodel/ED2/files/111103/8757397-dns-9ccb09b-v1_rapid.pdf)
