### PR TITLE
version specific gfortran in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 
 before_install:
     - sudo apt-get clean && sudo apt-get update
-    - sudo apt-get install gcc-4.6 hdf5-tools libmpich1.0-dev libhdf5-mpich-dev
+    - sudo apt-get install gcc-4.6 gfortran-4.6 hdf5-tools libmpich1.0-dev libhdf5-mpich-dev
 
 script:
     - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: c
 sudo: required
 
 before_install:
+    - sudo apt-get clean && sudo apt-get update
     - sudo apt-get install gcc-4.6 hdf5-tools
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: required
 
 before_install:
-    - sudo apt-get install gcc-4.6 libopenmpi-dev libhdf5-openmpi-dev
+    - sudo apt-get install gcc-4.6 hdf5-tools
 
 script:
     - make OPT=opt.gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ before_install:
     - sudo apt-get install gcc-4.6 hdf5-tools libmpich1.0-dev libhdf5-mpich-dev
 
 script:
-    - cd EDmodel/ED2/ED/build/bin
+    - pwd
+    - cd ED2/ED/build/bin
     - make OPT=opt.gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ before_install:
 
 script:
     - pwd
-    - cd ED2/ED/build/bin
+    - cd ED/build/bin
     - make OPT=opt.gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,5 @@ before_install:
 script:
     - pwd
     - cd ED/build/bin
+    - ./generate_deps.sh
     - make OPT=opt.gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: required
 
 before_install:
     - sudo apt-get clean && sudo apt-get update
-    - sudo apt-get install gcc-4.6 hdf5-tools
+    - sudo apt-get install gcc-4.6 hdf5-tools libmpich1.0-dev libhdf5-mpich-dev
 
 script:
+    - cd EDmodel/ED2/ED/build/bin
     - make OPT=opt.gfortran

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: c
 sudo: required
 
 before_install:
-    - sudo apt-get install gcc-4.6 gfortran-4.6 libhdf5-serial-dev
+    - sudo apt-get install gcc-4.6 libopenmpi-dev libhdf5-openmpi-dev
 
 script:
     - make OPT=opt.gfortran

--- a/ED/build/bin/include.mk.opt.gfortran
+++ b/ED/build/bin/include.mk.opt.gfortran
@@ -85,7 +85,7 @@ USE_MPIWTIME=1
 
 #----------------- gfortran on Linux (optimized build)-----------
 CMACH=PC_GFORTRAN
-F_COMP=mpif90
+F_COMP=gfortran-4.6
 F_OPTS=-g -ffree-line-length-none -fno-whole-file -O2 -fopenmp #-ffpe-trap=invalid,zero,overflow -fbounds-check  #-O2
 C_COMP=mpicc 
 C_OPTS=-g -O2 -fopenmp #-ffpe-trap=invalid,zero,overflow -fbounds-check #-O2


### PR DESCRIPTION
I believe the problem with #149 is that mpif90 specifies the compiler as "gfortran" whereas the actual call may need to specify the version. I've had this issue trying to install on Ubuntu, which I was able to solve by soft-linking gfortran to gfortran-4.9 within the openmpi build.