### PR TITLE
PFT -> analy output so BLEAF etc can be processed.

### DIFF
--- a/ED/src/memory/ed_state_vars.F90
+++ b/ED/src/memory/ed_state_vars.F90
@@ -24516,7 +24516,7 @@ module ed_state_vars
       if (associated(cpatch%pft)) then
          nvar=nvar+1
            call vtable_edio_i(npts,cpatch%pft,nvar,igr,init,cpatch%coglob_id, &
-           var_len,var_len_global,max_ptrs,'PFT :40:hist:dail:mont:dcyc:year') 
+           var_len,var_len_global,max_ptrs,'PFT :40:hist:anal:dail:mont:dcyc:year')
          call metadata_edio(nvar,igr,'Plant Functional Type','[-]','NA') 
       end if
 


### PR DESCRIPTION
IFOUTPUT files contain by-cohort variables but do not contain PFT information, so this fixes that.