### PR TITLE
Mortality bugfix

### DIFF
--- a/ED/src/dynamics/structural_growth.f90
+++ b/ED/src/dynamics/structural_growth.f90
@@ -148,9 +148,12 @@ subroutine structural_growth(cgrid, month)
                cpatch%monthly_dndt  (ico) = max( cpatch%monthly_dndt   (ico)               &
                                                , negligible_nplant     (ipft)              &
                                                - cpatch%nplant         (ico) )
-               cpatch%monthly_dlnndt(ico) = max( cpatch%monthly_dlnndt (ico)               &
-                                               , log( negligible_nplant(ipft)              &
-                                                    / cpatch%nplant    (ico) ) )
+               ! Avoid arithmetic overflow if negligible_nplant == 0 (Author: Alexey Shiklomanov)
+               if ( negligible_nplant(ipft) > tiny(negligible_nplant(ipft)) ) then
+                    cpatch%monthly_dlnndt(ico) = max( cpatch%monthly_dlnndt (ico)          &
+                                                    , log( negligible_nplant(ipft)         &
+                                                            / cpatch%nplant    (ico) ) )
+               end if
                cpatch%nplant(ico)         = cpatch%nplant(ico)                               &
                                           * exp(cpatch%monthly_dlnndt(ico))
                !---------------------------------------------------------------------------!

--- a/ED/src/utils/hdf5_utils.F90
+++ b/ED/src/utils/hdf5_utils.F90
@@ -432,7 +432,7 @@ subroutine shdf5_irec_f(ndims,dims,dsetname,ivara,rvara,cvara,dvara,lvara  &
   character(len=2) :: ctype
   
   logical :: convert = .false.
-  integer :: type_id
+  integer(HID_T) :: type_id
   real(kind=8), allocatable, dimension(:) :: dvaraTEMP
   
   ! Find which data type will be read


### PR DESCRIPTION
If `negligible_nplant` is 0 for a PFT, the `log` operation in the `monthly_dlnndt` calculation fails (`log(0)`) and causes the entire run to die. This introduces a simple check wherein the adjustment is only performed if `negligible_nplant(ipft)` is zero (to account for rounding errors, I define zero to be less than the smallest real of its type, as defined by `tiny`).

As far as I can tell, there are no edge cases where this would break something that should not have otherwise been broken. But, an alternative is to explicitly throw an error if `negligible_nplant` is zero -- that would be much less cryptic than the current mysterious `SIGFPE`.