### PR TITLE
fix bug for wood energy budget when IBRANCH_THERMO = 0 with plant hydraulics

### DIFF
--- a/ED/src/dynamics/rk4_misc.f90
+++ b/ED/src/dynamics/rk4_misc.f90
@@ -950,13 +950,17 @@ subroutine update_diagnostic_vars(initp, csite,ipa)
 
             !------------------------------------------------------------------------------!
             !wood, note that wood_water_int has different units between initp
-            !and cpatch
-            delta_water_int     = initp%wood_water_int(ico)                             &
-                                - dble(cpatch%wood_water_int(ico)) * dble(cpatch%nplant(ico))
-            ! kg/m2g
+            !and cpatch. Note that we do not need to update initp%wood_hcap if
+            !ibranch_thermo = 0 (wood is not tracked)
+            if (ibranch_thermo /= 0) then
+                delta_water_int     = initp%wood_water_int(ico)                         &
+                                    - dble(cpatch%wood_water_int(ico))                  &
+                                    * dble(cpatch%nplant(ico))
+                ! kg/m2g
 
-            initp%wood_hcap(ico)= dble(cpatch%wood_hcap(ico))                           &
-                                + delta_water_int * cliq8
+                initp%wood_hcap(ico)= dble(cpatch%wood_hcap(ico))                       &
+                                    + delta_water_int * cliq8
+            endif
             !------------------------------------------------------------------------------!
 
        enddo


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

When IBRANCH_THERMO = 0, wood_hcap should be always set to zero so wood energy and temperature are not dynamically tracked. The current mainline master modifies wood_hcap when plant hydraulics is enabled.

This is revised in the pull request by checking the IBRANCH_THERMO flag in rk4_misc.f90

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 