### PR TITLE
Add MPI_Finalize call at the end of edmain

### DIFF
--- a/ED/src/driver/edmain.F90
+++ b/ED/src/driver/edmain.F90
@@ -290,6 +290,7 @@ program main
    end if
 #endif
    if (icall == 0) then
+      call MPI_Finalize(ierr)
       write(unit=*,fmt='(a)') ' ------ ED-2.2 execution ends ------'
    end if
    !---------------------------------------------------------------------------------------!

--- a/ED/src/driver/edmain.F90
+++ b/ED/src/driver/edmain.F90
@@ -285,13 +285,13 @@ program main
 
    !----- Finishes execution. -------------------------------------------------------------!
 #if defined(RAMS_MPI)
-   if (ipara == 1) then
+   select case (isingle)
+   case (0)
       call MPI_Finalize(ierr)
-   end if
+   end select
 #endif
    if (icall == 0) then
-      call MPI_Finalize(ierr)
-      write(unit=*,fmt='(a)') ' ------ ED-2.2 execution ends ------'
+       write(unit=*,fmt='(a)') ' ------ ED-2.2 execution ends ------'
    end if
    !---------------------------------------------------------------------------------------!
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Added the following line in edmain.f90 for if (icall == 0) :
call MPI_Finalize(ierr)

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this MPI_Finalize call, the model does not finish cleanly on Harvard's Odyssey cluster. Though it produces output, it is considered 'failed' because 'mpirun has exited due to process rank 0 ... [node] exiting improperly'
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [x ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)
Will not change answers

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 