### PR TITLE
read fire hite thershold from XML config

### DIFF
--- a/ED/src/io/ed_xml_config.f90
+++ b/ED/src/io/ed_xml_config.f90
@@ -1051,6 +1051,8 @@ recursive subroutine read_ed_xml_config(filename)
         if(texist) agriculture_on = ival
         
         !! FIRE
+        call getConfigREAL  ('fire_hite_threshold','disturbance',i,rval,texist)
+        if(texist) fire_hite_threshold = real(rval)
         call getConfigREAL  ('fire_dryness_threshold','disturbance',i,rval,texist)
         if(texist) fire_dryness_threshold = real(rval)
         call getConfigREAL  ('fire_parameter','disturbance',i,rval,texist)
@@ -1775,6 +1777,7 @@ subroutine write_ed_xml_config
      call putConfigREAL("min_harvest_biomass",min_harvest_biomass)
      call putConfigREAL("mature_harvest_age",mature_harvest_age)
      ! --- Fire
+     call putConfigREAL("fire_hite_threshold",fire_hite_threshold)
      call putConfigINT("include_fire",include_fire)
      call putConfigREAL("fire_dryness_threshold",fire_dryness_threshold)
      call putConfigREAL("fire_parameter",fire_parameter)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Add ability to specify the fire_hite_threshold from XML. Parallels method of initializing treefall_hite_threshold.

## Description
<!--- Describe your changes in detail -->

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Unlike treefall_hite_threshold, only way to change the fire_hite_threshhold was to change ed_params.f90, which is not ideal.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.
(passed compile on Linux server)

<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 