### PR TITLE
Fix small bugs in observation time output 

### DIFF
--- a/ED/src/init/ed_init.F90
+++ b/ED/src/init/ed_init.F90
@@ -1180,7 +1180,7 @@ subroutine read_obstime()
                       ,'ed_init.F90')
    end if
 
-   if (outfast .ne. frqfast) then
+   if (.not.((outfast .eq. frqfast) .or. (outfast .eq. 0))) then
       write (unit=*,fmt='(a,1x,f7.0,1x,a)') &
          'OUTFAST must be 0 or equal to FRQFAST for observation time output. (Yours is ',outfast,').'
       call fatal_error('OUTFAST should be = FRQFAST or zero','read_obstime'                 &

--- a/ED/src/init/ed_init.F90
+++ b/ED/src/init/ed_init.F90
@@ -1156,7 +1156,7 @@ subroutine read_obstime()
    integer  :: ferr  ! error flag
    integer  :: time_idx
    integer  :: time_hms
-   real     :: sec_2_start, sec_2_end
+   real(kind=8)  :: sec_2_start, sec_2_end
 
    !---------------------------------------------------------------------------------------!
    !----- First thing, let's check whether observation time list file exists.  ------------!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Bug fixes in the observation output code having to do with:
(1) the ED2IN options under which an error is given
(2) conditions causing an observation time is discarded

## Description
<!--- Describe your changes in detail -->
(1) Allow OBSTIME == 0 in addition to OBSTIME == FRQFAST without crashing. Before, model crashed if OBSTIME .ne. FRQFAST.
(2) In the read_obstime subroutine in ed_init.F90, declare sec_2_start & sec_2_end as real(kind=8) instead of real. 'Real' didn't allow enough digits. As a result, sec_2_start & sec_2_end were weird numbers (often 0) rather than what they should have been. sec_2_start and sec_2_end are used to determine whether a given observation time was outside the simulation time. If the observation time is outside the simulation time, it is discarded.

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
(1) Model was crashing when OBSTIME .ne. FRQFAST. It should also run fine (and it does) if OBSTIME = 0. In this PR, I just changed the conditions of the error. 
(2) Now model times are only discarded when they should be (aka when they're outside the observation time).

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [ x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 