### PR TITLE
add condition iooutput/=0 for setting analysis_time to true

### DIFF
--- a/ED/src/driver/ed_model.F90
+++ b/ED/src/driver/ed_model.F90
@@ -325,7 +325,7 @@ subroutine ed_model()
       select case (unitfast)
       case (0,1) !----- Now both are in seconds -------------------------------------------!
          analysis_time   = mod(current_time%time, frqfast) < dtlsm .and.                   &
-                           (ifoutput /= 0 .or. itoutput /=0)
+                           (ifoutput /= 0 .or. itoutput /=0 .or. iooutput /=0)
          dcycle_time     = mod(current_time%time, frqfast) < dtlsm .and. iqoutput /= 0
       case (2)   !----- Months, analysis time is at the new month -------------------------!
          analysis_time   = new_month .and. (ifoutput /= 0 .or. itoutput /=0) .and.         &


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Simple edit to fix a bug which was causing DMEAN output to be incorrect when IOOUTPUT=3 but ITOUTPUT and IFOUTPUT=0

## Description
<!--- Describe your changes in detail -->
One added condition to make analysis_time true (iooutput=/0)

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->
Troubleshooting the origin of the DMEAN output gobbledegook with Xiangtao Xu

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Bug fix so that DMEAN output works regardless of IOOUTPUT settings
Issue: 274

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [x ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
Issue # 274
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 