### PR TITLE
[Bug Fix] use ground_shv to calculate ground evaporation

### DIFF
--- a/ED/src/dynamics/rk4_derivs.F90
+++ b/ED/src/dynamics/rk4_derivs.F90
@@ -1253,7 +1253,7 @@ subroutine canopy_derivs_two(mzg,initp,dinitp,csite,ipa,hflxsc,wflxsc,qwflxsc,hf
       ! the user is fine with super-saturation).                                           !
       !------------------------------------------------------------------------------------!
       wflxgc            = ( 1.d0 - initp%snowfac ) * initp%ggnet * initp%can_rhos          &
-                        * ( initp%ground_ssh - initp%can_shv )                             &
+                        * ( initp%ground_shv - initp%can_shv )                             &
                         * ( 1.d0 / (1.d0 + initp%ggnet / initp%ggsoil) )
       qwflxgc           = wflxgc * tq2enthalpy8(initp%ground_temp,1.d0,.true.)
       !----- Set flux flag. ---------------------------------------------------------------!


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Calculate ground evaporation using actual ground surface specific humidity. Previously, it was calculated using saturated specific humidity (ground_ssh), which can overestimate evaporation during hot dry period, and potentially create numerical instability.

## Description
<!--- Describe your changes in detail -->
Only one change in rk4_derivs.f90. Other uses of ground_ssh in the subroutine are valid (for dew formation calculations)

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [X] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
#285 
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 