### PR TITLE
Build files for MacOS with Homebrew libraries

### DIFF
--- a/ED/build/make/include.mk.macos_homebrew
+++ b/ED/build/make/include.mk.macos_homebrew
@@ -1,6 +1,9 @@
 #==========================================================================================#
 #==========================================================================================#
-#     Make file include.mk.opt.embrapa                                                     #
+# ED2 installation options for MacOS with additional libraries installed via Homebrew.
+# Make sure you have the following libraries installed (`brew install <library>`):
+# - hdf5
+# - gfortran
 #------------------------------------------------------------------------------------------#
 
 
@@ -20,11 +23,10 @@ BASE=$(ED_ROOT)/build/
 # libraries compiled with the same compiler you set for F_COMP and C_COMP.  You may still  #
 # be able to compile without HDF5 but it will not run.                                     #
 #------------------------------------------------------------------------------------------#
-ZLIB_PATH=/Users/mlongo/Util/ED2_Libs/zlib-1.2.11
-HDF5_PATH=/Users/mlongo/Util/ED2_Libs/hdf5-1.10.2
-HDF5_INCS=-I$(HDF5_PATH)/include
+BREW_PREFIX=/usr/local
+HDF5_INCS=-I$(BREW_PREFIX)/include
 HDF5C_INCS=$(HDF5_INCS)
-HDF5_LIBS=-L$(ZLIB_PATH)/lib -lz -L$(HDF5_PATH)/lib -lhdf5_fortran -lhdf5 -lhdf5_hl
+HDF5_LIBS=-L$(BREW_PREFIX)/lib -lhdf5_fortran -lhdf5 -lhdf5_hl -lz
 #------------------------------------------------------------------------------------------#
 
 
@@ -126,6 +128,5 @@ PAR_DEFS=
 #------------------------------------------------------------------------------------------#
 #      Archive options for Mac OS X.                                                       #
 #------------------------------------------------------------------------------------------#
-#ARCHIVE=libtool -c -static -stack_size 0x1000000 -o
 ARCHIVE=ar rs
 #------------------------------------------------------------------------------------------#

--- a/ED/build/make/include.mk.macos_homebrew
+++ b/ED/build/make/include.mk.macos_homebrew
@@ -90,12 +90,12 @@ endif
 ifeq ($(KIND_COMP),A)
    F_OPTS= -O0 -ffree-line-length-none -g -fimplicit-none -Wall -finit-real=snan           \
            -finit-integer=-2147483648 -ffpe-trap=invalid,zero,overflow,underflow           \
-           -fcheck=all -frecursive -fsignaling-nans -Werror -mmacosx-version-min=10.12     \
+           -fcheck=all -fsignaling-nans -Werror -mmacosx-version-min=10.12     \
            -fopenmp -static
    C_OPTS= -O0 -DLITTLE  -g -static
    LOADER_OPTS= -O0 -ffree-line-length-none -g -fimplicit-none -Wall -finit-real=snan      \
                 -finit-integer=-2147483648 -ffpe-trap=invalid,zero,overflow,underflow      \
-                -fcheck=all -frecursive -fsignaling-nans -Werror                           \
+                -fcheck=all -fsignaling-nans -Werror                           \
                 -mmacosx-version-min=10.12 -fopenmp
    #---------------------------------------------------------------------------------------#
 endif

--- a/ED/build/make/include.mk.macos_homebrew
+++ b/ED/build/make/include.mk.macos_homebrew
@@ -1,0 +1,131 @@
+#==========================================================================================#
+#==========================================================================================#
+#     Make file include.mk.opt.embrapa                                                     #
+#------------------------------------------------------------------------------------------#
+
+
+#----- Define make (gnu make works best). -------------------------------------------------#
+MAKE=/usr/bin/make
+#------------------------------------------------------------------------------------------#
+
+#----- Libraries. -------------------------------------------------------------------------#
+BASE=$(ED_ROOT)/build/
+#------------------------------------------------------------------------------------------#
+
+
+#------------------------------------------------------------------------------------------#
+#     HDF5 libraries                                                                       #
+#                                                                                          #
+#     Since ED-2.1, this is no longer optional for real simulations.  You must have HDF5   #
+# libraries compiled with the same compiler you set for F_COMP and C_COMP.  You may still  #
+# be able to compile without HDF5 but it will not run.                                     #
+#------------------------------------------------------------------------------------------#
+ZLIB_PATH=/Users/mlongo/Util/ED2_Libs/zlib-1.2.11
+HDF5_PATH=/Users/mlongo/Util/ED2_Libs/hdf5-1.10.2
+HDF5_INCS=-I$(HDF5_PATH)/include
+HDF5C_INCS=$(HDF5_INCS)
+HDF5_LIBS=-L$(ZLIB_PATH)/lib -lz -L$(HDF5_PATH)/lib -lhdf5_fortran -lhdf5 -lhdf5_hl
+#------------------------------------------------------------------------------------------#
+
+
+#------------------------------------------------------------------------------------------#
+#      If you have a version of hdf5 compiled in parallel, then you may benefit from       #
+# collective I/O, then use this flag = 1.  Otherwise, set it to zero.                      #
+#------------------------------------------------------------------------------------------#
+USE_COLLECTIVE_MPIO=0
+#------------------------------------------------------------------------------------------#
+
+
+
+
+#------------------------------------------------------------------------------------------#
+#      This should be 1 unless you are running with -gen-interfaces.  Interfaces usually   #
+# make the compilation to crash when the -gen-interfaces option are on, so this flag       #
+# bypass all interfaces in the code.                                                       #
+#------------------------------------------------------------------------------------------#
+USE_INTERF=1
+#------------------------------------------------------------------------------------------#
+
+
+
+#################################### COMPILER SETTINGS #####################################
+CMACH=MAC_OS_X
+FC_TYPE=GNU
+F_COMP=gfortran
+C_COMP=gcc
+LOADER=gfortran
+C_LOADER=gcc
+LIBS=
+MOD_EXT=mod
+############################################################################################
+
+
+
+
+
+##################################### COMPILER OPTIONS #####################################
+#------------------------------------------------------------------------------------------#
+# A. Pickiest   - Use this whenever you change arguments on functions and subroutines.     #
+#                 This will perform the same tests as B but it will also check whether all #
+#                 arguments match between subroutine declaration and subroutine calls.     #
+#                 WARNING: In order to really check all interfaces you must compile with   #
+#                          this option twice:                                              #
+#                 1. Compile (./install.sh A)                                              #
+#                 2. Prepare second compilation(./2ndcomp.sh)                              #
+#                 3. Compile one more time (./install.sh B)                                #
+#                 If the compilation fails either at step 3, then your code has interface  #
+#                 problems. If it successfully compiles, then the code is fine for         #
+#                 interfaces.                                                              #
+# E. Fast - This is all about performance, use only when you are sure that the model has   #
+#           no code problem, and you want results asap. This will not check for any        #
+#           problems, which means that this is an option suitable for end users, not de-   #
+#           velopers.                                                                      #
+#------------------------------------------------------------------------------------------#
+ifeq ($(KIND_COMP),)
+   KIND_COMP=E
+endif
+#------------------------------------------------------------------------------------------#
+ifeq ($(KIND_COMP),A)
+   F_OPTS= -O0 -ffree-line-length-none -g -fimplicit-none -Wall -finit-real=snan           \
+           -finit-integer=-2147483648 -ffpe-trap=invalid,zero,overflow,underflow           \
+           -fcheck=all -frecursive -fsignaling-nans -Werror -mmacosx-version-min=10.12     \
+           -fopenmp -static
+   C_OPTS= -O0 -DLITTLE  -g -static
+   LOADER_OPTS= -O0 -ffree-line-length-none -g -fimplicit-none -Wall -finit-real=snan      \
+                -finit-integer=-2147483648 -ffpe-trap=invalid,zero,overflow,underflow      \
+                -fcheck=all -frecursive -fsignaling-nans -Werror                           \
+                -mmacosx-version-min=10.12 -fopenmp
+   #---------------------------------------------------------------------------------------#
+endif
+ifeq ($(KIND_COMP),E)
+   F_OPTS= -O3 -ffree-line-length-none -frecursive -mmacosx-version-min=10.12 -fopenmp     \
+           -static
+   C_OPTS= -O0 -DLITTLE  -g  -static
+   LOADER_OPTS= -O3 -ffree-line-length-none -frecursive -mmacosx-version-min=10.12 -fopenmp
+   #---------------------------------------------------------------------------------------#
+endif
+#------------------------------------------------------------------------------------------#
+############################################################################################
+
+
+
+
+#------------------------------------------------------------------------------------------#
+#     If using mpicc and mpif90 as compilers (recommended), leave MPI_PATH, PAR_INCS, and  #
+# PAR_LIBS blank, otherwise provide the includes and libraries for mpi.  Either way, don't #
+# change PAR_DEFS.                                                                         #
+#------------------------------------------------------------------------------------------#
+MPI_PATH=
+PAR_INCS=
+PAR_LIBS=
+PAR_DEFS=
+#------------------------------------------------------------------------------------------#
+
+
+
+#------------------------------------------------------------------------------------------#
+#      Archive options for Mac OS X.                                                       #
+#------------------------------------------------------------------------------------------#
+#ARCHIVE=libtool -c -static -stack_size 0x1000000 -o
+ARCHIVE=ar rs
+#------------------------------------------------------------------------------------------#

--- a/ED/build/make/include.mk.macos_homebrew
+++ b/ED/build/make/include.mk.macos_homebrew
@@ -95,15 +95,13 @@ ifeq ($(KIND_COMP),A)
    C_OPTS= -O0 -DLITTLE  -g -static
    LOADER_OPTS= -O0 -ffree-line-length-none -g -fimplicit-none -Wall -finit-real=snan      \
                 -finit-integer=-2147483648 -ffpe-trap=invalid,zero,overflow,underflow      \
-                -fcheck=all -fsignaling-nans -Werror                           \
-                -mmacosx-version-min=10.12
+                -fcheck=all -fsignaling-nans -Werror -mmacosx-version-min=10.12
    #---------------------------------------------------------------------------------------#
 endif
 ifeq ($(KIND_COMP),E)
-   F_OPTS= -O3 -ffree-line-length-none -frecursive -mmacosx-version-min=10.12 -fopenmp     \
-           -static
+   F_OPTS= -O3 -ffree-line-length-none -mmacosx-version-min=10.12 -static
    C_OPTS= -O0 -DLITTLE  -g  -static
-   LOADER_OPTS= -O3 -ffree-line-length-none -frecursive -mmacosx-version-min=10.12 -fopenmp
+   LOADER_OPTS= -O3 -ffree-line-length-none -mmacosx-version-min=10.12
    #---------------------------------------------------------------------------------------#
 endif
 #------------------------------------------------------------------------------------------#

--- a/ED/build/make/include.mk.macos_homebrew
+++ b/ED/build/make/include.mk.macos_homebrew
@@ -91,12 +91,12 @@ ifeq ($(KIND_COMP),A)
    F_OPTS= -O0 -ffree-line-length-none -g -fimplicit-none -Wall -finit-real=snan           \
            -finit-integer=-2147483648 -ffpe-trap=invalid,zero,overflow,underflow           \
            -fcheck=all -fsignaling-nans -Werror -mmacosx-version-min=10.12     \
-           -fopenmp -static
+           -static
    C_OPTS= -O0 -DLITTLE  -g -static
    LOADER_OPTS= -O0 -ffree-line-length-none -g -fimplicit-none -Wall -finit-real=snan      \
                 -finit-integer=-2147483648 -ffpe-trap=invalid,zero,overflow,underflow      \
                 -fcheck=all -fsignaling-nans -Werror                           \
-                -mmacosx-version-min=10.12 -fopenmp
+                -mmacosx-version-min=10.12
    #---------------------------------------------------------------------------------------#
 endif
 ifeq ($(KIND_COMP),E)

--- a/EDTS/run-test.sh
+++ b/EDTS/run-test.sh
@@ -47,9 +47,11 @@ mkdir -p "$OUTDIR"
 mkdir -p "test-logs"
 LOGFILE="test-logs/$TESTNAME"
 
-# Remove the stack limit. Otherwise, ED2 will mysteriously segfault early in its
-# excution.
-ulimit -s unlimited
+if ! uname -a | grep -q -i "darwin"; then
+    # Remove the stack limit. Otherwise, ED2 will mysteriously segfault early in
+    # its excution. But don't do this check on MacOS.
+    ulimit -s unlimited
+fi
 
 # Run without OMP.
 # TODO: Test execution with OMP


### PR DESCRIPTION
[Homebrew](https://brew.sh/) is a pretty common approach to managing packages on MacOS. This PR adds a new "platform", `macos_homebrew`, for installing on most MacOS systems. The key changes are:

- The HDF5 headers and libraries are looked-for where Homebrew installs them, namely `/usr/local/include` and `/usr/local/lib`, respectively.
- Zlib (`-lz --> libz.so`) ships natively with modern versions of MacOS (it's located in `/usr/lib/libz.so`) and seems to work fine with ED-2.2, so there shouldn't be a need to install a custom version.
- The `-frecursive` and `-fopenmp` flags seem to cause Segmentation Faults on MacOS. As far as I understand,`-frecursive` dumps _every_ array onto the stack, which causes a stack overflow (which cannot be avoided by removing the stack limit with `ulimit -s unlimited` because MacOS has a hard-coded system stack limit). I'm not sure why `-fopenmp` causes a segmentation fault, but it does. Site-level simulations of ED2 run just fine on a single CPU.

Adding a MacOS compilation and execution test to the CI is on my to-do list, but exceeds my current familiarity with GitHub Actions.