### PR TITLE
Minor typos in ed_state_vars

### DIFF
--- a/ED/src/memory/ed_state_vars.F90
+++ b/ED/src/memory/ed_state_vars.F90
@@ -15421,7 +15421,7 @@ module ed_state_vars
          nvar = nvar+1
          call vtable_edio_r(npts,cgrid%dmean_sapa_storage_resp                             &
                            ,nvar,igr,init,cgrid%pyglob_id,var_len,var_len_global,max_ptrs  &
-                           ,'DMEAN_SAPB_STORAGE_RESP_PY      :11:'//trim(dail_keys)     )
+                           ,'DMEAN_SAPA_STORAGE_RESP_PY      :11:'//trim(dail_keys)     )
          call metadata_edio(nvar,igr                                                       &
                            ,'Daily mean - Aboveground Sapwood Storage respiration'         &
                            ,'[  kgC/m2/yr]','(ipoly)'            )

--- a/ED/src/memory/ed_state_vars.F90
+++ b/ED/src/memory/ed_state_vars.F90
@@ -33062,7 +33062,7 @@ module ed_state_vars
          call vtable_edio_r(npts,cpatch%mort_rate                                          &
                            ,nvar,igr,init,cpatch%coglob_id,var_len,var_len_global,max_ptrs &
                            ,'MORT_RATE_CO :48:hist:dail') 
-         call metadata_edio(nvar,igr,'Mortality rates','[1/yr]','icohort') 
+         call metadata_edio(nvar,igr,'Mortality rates','[1/yr]','imort,icohort')
       end if
       !------------------------------------------------------------------------------------!
 
@@ -33091,7 +33091,7 @@ module ed_state_vars
          call vtable_edio_r(npts,cpatch%mmean_mort_rate                                    &
                            ,nvar,igr,init,cpatch%coglob_id,var_len,var_len_global,max_ptrs &
                            ,'MMEAN_MORT_RATE_CO :48:'//trim(eorq_keys))
-         call metadata_edio(nvar,igr,'Monthly mean mortality rate','[1/yr]','icohort')
+         call metadata_edio(nvar,igr,'Monthly mean mortality rate','[1/yr]','imort,icohort')
       end if
       !------------------------------------------------------------------------------------!
       !------------------------------------------------------------------------------------!


### PR DESCRIPTION
Two small output variable discrepancies:
- Incorrect metadata for mortality variables (they are `n_mort x ncohorts`, but are listed as `ncohorts`)
- Writing `SAPA` storage respiration as `SAPB`