### PR TITLE
Sanitize history.xml string output

### DIFF
--- a/ED/src/io/ed_xml_config.f90
+++ b/ED/src/io/ed_xml_config.f90
@@ -2259,7 +2259,6 @@ subroutine write_ed_xml_config
      call putConfigINT  ("fuse_relax"         ,ival               )
      !------ New patch/cohort fusion parameters
      call putConfigINT  ("niter_patfus"       ,niter_patfus       )
-     call putConfigREAL ("lai_fuse_tol"       ,lai_fuse_tol       )
      call putConfigREAL ("pat_light_tol_min"  ,pat_light_tol_min  )
      call putConfigREAL ("pat_light_tol_max"  ,pat_light_tol_max  )
      call putConfigREAL ("pat_light_tol_mult" ,pat_light_tol_mult )

--- a/ED/src/io/ed_xml_config.f90
+++ b/ED/src/io/ed_xml_config.f90
@@ -2376,7 +2376,11 @@ subroutine putConfigSTRING(tag,value)
   character(*),intent(in) :: tag 
   character(*),intent(in) :: value
   integer :: lenval 
-  lenval = len(value)
+  !! `len(value)` includes trailing whitespace and other stuff, but below, we
+  !! only write `trim(value)`, which is shorter. This leads to a bunch of
+  !! non-readable garbage getting dumped into the output file. We can avoid that
+  !! by doing `len(trim(value))` here, so the lengths match.
+  lenval = len(trim(value))
   call libxml2f90_ll_opentag(tag)
   call libxml2f90_ll_addid(trim(tag),lenval,trim(value))
   call libxml2f90_ll_closetag(tag)


### PR DESCRIPTION
`len(value)` > `len(trim(value))`, so when we tell Fortran to write a string of length `len(value)` but only give it `len(trim(value))` characters, it fills the rest with unreadable garbage that trips up most file readers. This small fix ensures that we only write out as many characters as we mean to.

EDIT: Also, remove duplicate `lai_fuse_tol` from XML output. I'm not sure if there's something else that should be there instead, but currently, it just writes out the same value twice in the same section, which seems unnecessary.