### PR TITLE
Bug fix when ISLCOLFLG=1

### DIFF
--- a/ED/src/mpi/ed_para_init.f90
+++ b/ED/src/mpi/ed_para_init.f90
@@ -422,7 +422,7 @@ subroutine get_work(ifm,nxp,nyp,is_poi)
    select case (islcolflg(ifm))
    case (1)
       call leaf_database(trim(slcol_database(ifm)),maxsite,npoly,'soil_col'                &
-                        ,lat_list,lon_list,ntext_soil_list,ipcent_slcol)
+                        ,lat_list,lon_list,ncol_soil_list,ipcent_slcol)
    case default
       !------------------------------------------------------------------------------------!
       !   Allow for only one site by making the first site with the default soil type and  !


### PR DESCRIPTION
Minor bug fix on the variable passed to leaf_database for reading soil colour files.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

I replaced the variable where soil colour information is stored when reading gridded maps. This bug would cause the code to incorrectly assign soil texture when ISLCOLFLG=1. 

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This avoids the model to assign incorrect soil texture types when ISLCOLFLG=1

<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [x] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 