### PR TITLE
Add ability to create ED docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,95 @@
+name: Docker
+
+# This will run when:
+# - when new code is pushed to master to push the tags latest.
+# - when a pull request is created and updated  to make sure the
+#   Dockerfile is still valid.
+
+# To be able to push to dockerhub, this expects the following
+# secrets to be set in the project:
+# - DOCKERHUB_USERNAME : username that can push to the org
+# - DOCKERHUB_PASSWORD : password asscoaited with the username
+
+# To be able to push to github, this expects the following
+# secrets to be set in the project:
+# - GHCR_USERNAME : username that can push to the org
+# - GHCR_PASSWORD : password asscoaited with the username
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+
+# Certain actions will only run when this is the master repo.
+env:
+  MASTER_REPO: EDModel/ED2
+  DOCKERHUB_ORG: pecan
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      # calculate some variables that are used later
+      - name: github branch
+        run: |
+          BRANCH=${GITHUB_REF##*/}
+          if [ "$BRANCH" == "master" ]; then
+            TAGS="latest"
+          else
+            TAGS="$BRANCH"
+          fi
+          echo "TAGS=${TAGS}" >> $GITHUB_ENV
+          echo "GITHUB_BRANCH=${BRANCH}" >> $GITHUB_ENV
+
+      # build the docker image, this will always run to make sure
+      # the Dockerfile still works.
+      - name: Build image
+        uses: elgohr/Publish-Docker-Github-Action@2.22
+        env:
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
+        with:
+          registry: docker.pkg.github.com
+          name: ${{ github.repository_owner }}/${{ github.event.repository.name }}/ed
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: "${{ env.TAGS }}"
+          buildargs: BRANCH,BUILDNUMBER,GITSHA1
+          no_push: true
+
+      # this will publish to github container registry
+      - name: Publish to GitHub
+        if: github.event_name == 'push' && github.repository == env.MASTER_REPO
+        uses: elgohr/Publish-Docker-Github-Action@2.22
+        env:
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
+        with:
+          registry: ghcr.io
+          name: ${{ github.repository_owner }}/ed
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_PASSWORD }}
+          tags: "${{ env.TAGS }}"
+          buildargs: BRANCH,BUILDNUMBER,GITSHA1
+
+      # this will publish to the pecan dockerhub repo
+      - name: Publish to Docker Hub
+        if: github.event_name == 'push' && github.repository == env.MASTER_REPO
+        uses: elgohr/Publish-Docker-Github-Action@2.22
+        env:
+          BRANCH: ${{ env.GITHUB_BRANCH }}
+          BUILDNUMBER: ${{ github.run_number }}
+          GITSHA1: ${{ github.sha  }}
+        with:
+          name: ${{ env.DOCKERHUB_ORG }}/ed
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          tags: "${{ env.TAGS }}"
+          buildargs: BRANCH,BUILDNUMBER,GITSHA1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+# ----------------------------------------------------------------------
+# BUILD MODEL BINARY
+# ----------------------------------------------------------------------
+FROM debian:buster-slim AS builder
+
+# Some variables that can be used to set control the docker build
+ARG MODEL_VERSION="2.2.0"
+ARG BINARY_VERSION="2.2"
+
+# specify fortran compiler
+ENV FC_TYPE=GNU
+
+# install dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       build-essential \
+       curl \
+       gfortran \
+       git \
+       libhdf5-dev \
+       libopenmpi-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# download, unzip and build ed2
+COPY . /src/
+WORKDIR /src/ED/build
+RUN ./install.sh -g -p docker && mv ed_*-opt ed
+
+########################################################################
+
+# ----------------------------------------------------------------------
+# BUILD PECAN FOR MODEL
+# ----------------------------------------------------------------------
+FROM debian:buster-slim
+
+# ----------------------------------------------------------------------
+# INSTALL MODEL SPECIFIC PIECES
+# ----------------------------------------------------------------------
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       libhdf5-103 \
+       libopenmpi3 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /data
+
+# Some variables that can be used to set control the docker build
+ARG MODEL_VERSION="2.2.0"
+ENV MODEL_VERSION="${MODEL_VERSION}"
+
+# COPY model binary
+COPY --from=builder /src/ED/build/ed /usr/local/bin/ed
+
+

--- a/ED/build/make/include.mk.docker
+++ b/ED/build/make/include.mk.docker
@@ -1,0 +1,47 @@
+#Makefile include include.mk.opt.ubuntu
+############################################################################
+
+# Define make (gnu make works best).
+MAKE=/usr/bin/make
+
+# libraries.
+BASE=$(ED_ROOT)/build/
+
+# HDF 5  Libraries
+USE_HDF5=1
+HDF5_INCS=-I/usr/include/hdf5/serial
+HDF5_LIBS=-L/usr/lib/x86_64-linux-gnu/hdf5/serial -lz -lhdf5_fortran -lhdf5 -lhdf5_hl
+#HDF5_INCS=-I/usr/include
+#HDF5_LIBS=-lz -lhdf5_fortran -lhdf5 -lhdf5_hl
+USE_COLLECTIVE_MPIO=0
+
+# netCDF libraries
+USENC=0
+NC_LIBS=-L/dev/null
+
+# interface
+USE_INTERF=1
+
+# MPI_Wtime
+USE_MPIWTIME=1
+
+# gfortran
+CMACH=PC_LINUX1
+F_COMP=mpif90
+F_OPTS=-O3 -ffree-line-length-none  -fno-whole-file
+C_COMP=mpicc
+C_OPTS=-O3
+LOADER=mpif90
+LOADER_OPTS=${F_OPTS}
+C_LOADER=mpicc
+LIBS=
+MOD_EXT=mod
+
+# using MPI libraries:
+MPI_PATH=
+PAR_INCS=
+PAR_LIBS=
+PAR_DEFS=-DRAMS_MPI
+
+# For IBM,HP,SGI,ALPHA,LINUX use these:
+ARCHIVE=ar rs


### PR DESCRIPTION
This will create a docker image of ED. The image is based on debian (buster). The final image will only have he binary and the required libraries. No other files are installed. The binary is called `/usr/local/bin/ed`

Image will also be build using github actions and pushed to pecan/ed (for now)

## Motivation and Context

A docker container will make it easier to get started with ED, there is no need for the user to compile the model and have all required dependencies. This requires for docker to be installed.

For example to run one of the tests:

```
docker run -ti --rm \
           --volume ${PWD}:/data \
           pecan/ed \
           /usr/local/bin/ed -s -f "ED2IN-tonzi.harvest"
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [X] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [X] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 