### PR TITLE
Bug fix for croplands/pastures (reproduction.f90)

### DIFF
--- a/ED/src/dynamics/reproduction.f90
+++ b/ED/src/dynamics/reproduction.f90
@@ -27,6 +27,7 @@ module reproduction
                                      , one_plant_c                 & ! intent(in)
                                      , c2n_recruit                 & ! intent(in)
                                      , include_pft                 & ! intent(in)
+                                     , include_pft_pt              & ! intent(in)
                                      , include_pft_ag              & ! intent(in)
                                      , include_pft_fp              & ! intent(in)
                                      , q                           & ! intent(in)
@@ -235,9 +236,9 @@ module reproduction
                      !---------------------------------------------------------------------!
                      select case (csite%dist_type(ipa))
                      case (1)
-                        !----- Agriculture (cropland or pasture). -------------------------!
+                        !----- Pasture. ---------------------------------------------------!
                         allow_pft =                                                        &
-                           include_pft_ag(ipft)                                      .and. &
+                           include_pft_pt(ipft)                                      .and. &
                            cpoly%min_monthly_temp(isi) >= plant_min_temp(ipft) - 5.0 .and. &
                            repro_scheme                /= 0
                         !------------------------------------------------------------------!
@@ -246,6 +247,13 @@ module reproduction
                         !----- Forest plantation. -----------------------------------------!
                         allow_pft =                                                        &
                            include_pft_fp(ipft)                                      .and. &
+                           cpoly%min_monthly_temp(isi) >= plant_min_temp(ipft) - 5.0 .and. &
+                           repro_scheme                /= 0
+                        !------------------------------------------------------------------!
+                     case (8)
+                        !----- Cropland. --------------------------------------------------!
+                        allow_pft =                                                        &
+                           include_pft_ag(ipft)                                      .and. &
                            cpoly%min_monthly_temp(isi) >= plant_min_temp(ipft) - 5.0 .and. &
                            repro_scheme                /= 0
                         !------------------------------------------------------------------!
@@ -732,9 +740,9 @@ module reproduction
                      !---------------------------------------------------------------------!
                      select case (csite%dist_type(ipa))
                      case (1)
-                        !----- Agriculture (cropland or pasture). -------------------------!
+                        !----- Pasture. ---------------------------------------------------!
                         allow_pft =                                                        &
-                           include_pft_ag(ipft)                                      .and. &
+                           include_pft_pt(ipft)                                      .and. &
                            cpoly%min_monthly_temp(isi) >= plant_min_temp(ipft) - 5.0 .and. &
                            repro_scheme                /= 0
                         !------------------------------------------------------------------!
@@ -743,6 +751,14 @@ module reproduction
                         !----- Forest plantation. -----------------------------------------!
                         allow_pft =                                                        &
                            include_pft_fp(ipft)                                      .and. &
+                           cpoly%min_monthly_temp(isi) >= plant_min_temp(ipft) - 5.0 .and. &
+                           repro_scheme                /= 0
+                        !------------------------------------------------------------------!
+
+                     case (8)
+                        !----- Cropland. --------------------------------------------------!
+                        allow_pft =                                                        &
+                           include_pft_ag(ipft)                                      .and. &
                            cpoly%min_monthly_temp(isi) >= plant_min_temp(ipft) - 5.0 .and. &
                            repro_scheme                /= 0
                         !------------------------------------------------------------------!
@@ -931,6 +947,7 @@ module reproduction
                                     , seed_rain             & ! intent(in)
                                     , one_plant_c           & ! intent(in)
                                     , include_pft           & ! intent(in)
+                                    , include_pft_pt        & ! intent(in)
                                     , include_pft_ag        & ! intent(in)
                                     , include_pft_fp        ! ! intent(in)
       use ed_misc_coms       , only : ibigleaf              & ! intent(in)
@@ -1014,9 +1031,9 @@ module reproduction
                   !------------------------------------------------------------------------!
                   select case (csite%dist_type(ipa))
                   case (1)
-                     !----- Agriculture (cropland or pasture). ----------------------------!
+                     !----- Pasture. ------------------------------------------------------!
                      allow_pft =                                                           &
-                        include_pft_ag(ipft)                                      .and.    &
+                        include_pft_pt(ipft)                                      .and.    &
                         cpoly%min_monthly_temp(isi) >= plant_min_temp(ipft) - 5.0 .and.    &
                         repro_scheme                /= 0
                      !---------------------------------------------------------------------!
@@ -1025,6 +1042,14 @@ module reproduction
                      !----- Forest plantation. --------------------------------------------!
                      allow_pft =                                                           &
                         include_pft_fp(ipft)                                      .and.    &
+                        cpoly%min_monthly_temp(isi) >= plant_min_temp(ipft) - 5.0 .and.    &
+                        repro_scheme                /= 0
+                     !---------------------------------------------------------------------!
+
+                  case (8)
+                     !----- Cropland. -----------------------------------------------------!
+                     allow_pft =                                                           &
+                        include_pft_ag(ipft)                                      .and.    &
                         cpoly%min_monthly_temp(isi) >= plant_min_temp(ipft) - 5.0 .and.    &
                         repro_scheme                /= 0
                      !---------------------------------------------------------------------!


### PR DESCRIPTION
It seems the reproduction code was not updated when pastures and croplands were split.  This fix now allows for pastures PFTs to reproduce in dist_type = 1, and cropland PFTs to reproduce in dist_type = 8.  I believe this addresses the fix on #334 (thanks @mccabete for spotting it).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [ x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 