### PR TITLE
Reduce maximum dimensions for Mac OS

### DIFF
--- a/ED/src/memory/ed_max_dims.F90
+++ b/ED/src/memory/ed_max_dims.F90
@@ -48,6 +48,20 @@ module ed_max_dims
    integer, parameter :: maxdimp = brams_maxdimp
    integer, parameter :: nxyzpm  = brams_nxyzpm 
    integer, parameter :: maxmach = brams_maxmach
+#elif defined(MAC_OS_X)
+   ! Restrict maximum size to avoid stack memory issues
+   integer, parameter :: maxgrds  = 3
+   integer, parameter :: nxpmax   = 50
+   integer, parameter :: nypmax   = 50
+   integer, parameter :: nzpmax   = 50
+   integer, parameter :: nzgmax   = 30
+   integer, parameter :: maxdim   = 50
+   integer, parameter :: maxdimp  = maxdim + 2
+   integer, parameter :: nxyzpm   = nzpmax * nxpmax * nypmax
+   integer, parameter :: maxmach  = 20
+   integer, parameter :: ed_nstyp = 17             ! total # of soil textural classes
+   integer, parameter :: ed_nscol = 21             ! total # of soil colour classes
+   integer, parameter :: ed_nvtyp = 21
 #else
    integer, parameter :: maxgrds = 10
    integer, parameter :: nxpmax  = 666
@@ -236,8 +250,13 @@ module ed_max_dims
    !  MAX_WATER    - maximum number of soil water levels (not assigned to polygons).       !
    !---------------------------------------------------------------------------------------!
    integer, parameter :: huge_polygon = nxpmax * nypmax
+#if defined(MAC_OS_X)
+   integer, parameter :: huge_patch   = 200
+   integer, parameter :: huge_cohort  = 8000
+#else
    integer, parameter :: huge_patch   = 10000
    integer, parameter :: huge_cohort  = 250000
+#endif
    integer, parameter :: max_water    = 100
    !---------------------------------------------------------------------------------------!
 
@@ -258,6 +277,8 @@ module ed_max_dims
    !----- Maximum number of files that can be read by filelist. ---------------------------!
 #if defined(COUPLED)
    integer, parameter :: maxfiles = brams_maxfiles
+#elif defined(MAC_OS_X)
+   integer, parameter :: maxfiles = 999
 #else
    integer, parameter :: maxfiles = 99999
 #endif
@@ -265,7 +286,11 @@ module ed_max_dims
 
 
    !----- Maximum observation times that can be stored by the obs_timelist ----------------!
+#if defined(MAC_OS_X)
+   integer, parameter :: max_obstime = 999
+#else
    integer, parameter :: max_obstime = 99999
+#endif
    !---------------------------------------------------------------------------------------!
 
 


### PR DESCRIPTION
The maximum dimensions of several properties exceed the maximum stack memory usage in Mac OS X. Assuming that most use of ED2 with Mac OS X is for small simulations, I added preprocessor instructions to ed_max_dims.F90 to make these dimensions substantially lower when the machine is set to MAC_OS_X. With these minor edits, I was able to successfully compile and run ED2 on my Mac.

These edits should not have any impact on other systems, as long as people are not setting CMACH=MAC_OS_X to compile ED2 on non-Mac systems (which they shouldn't be doing in any case).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 