### PR TITLE
Skip derivation of light phenology parameters

### DIFF
--- a/ED/src/init/ed_params.f90
+++ b/ED/src/init/ed_params.f90
@@ -8049,6 +8049,7 @@ subroutine init_derived_params_after_xml()
                                    , undef_real                ! ! intent(in)
    use consts_coms          , only : onesixth                  & ! intent(in)
                                    , twothirds                 & ! intent(in)
+                                   , solar                     & ! intent(in)
                                    , t008                      & ! intent(in)
                                    , cliq                      & ! intent(in)
                                    , day_sec                   & ! intent(in)
@@ -8308,7 +8309,8 @@ subroutine init_derived_params_after_xml()
                                    , k_rh_active               & ! intent(out)
                                    , rh08                      & ! intent(out)
                                    , rh_q108                   ! ! intent(out)
-   use phenology_coms       , only : repro_scheme              & ! intent(in)
+   use phenology_coms       , only : iphen_scheme              & ! intent(in)
+                                   , repro_scheme              & ! intent(in)
                                    , radint                    & ! intent(in)
                                    , radslp                    & ! intent(in)
                                    , radavg_window             & ! intent(in)
@@ -8478,24 +8480,40 @@ subroutine init_derived_params_after_xml()
 
    !---------------------------------------------------------------------------------------!
    !      Minimum and maximum radiation should be defined according to the                 !
-   ! economics_scheme, as the model formulation is different.                              !
+   ! economics_scheme, as the model formulation is different.  But set dummy values for    !
+   ! both in case this simulation is not using light-controlled phenology.                 !
    !---------------------------------------------------------------------------------------!
-   select case (economics_scheme)
-   case (1)
+   select case (iphen_scheme)
+   case (3)
       !------------------------------------------------------------------------------------!
-      !      Turnover amplitude is a log-linear function of radiation, based on litter     !
-      ! fall data directly related to radiation.                                           !
+      !    Light phenology is enabled.                                                     !
       !------------------------------------------------------------------------------------!
-      radto_min = (turnamp_min / radint) ** (1./radslp)
-      radto_max = (turnamp_max / radint) ** (1./radslp)
+      select case (economics_scheme)
+      case (1)
+         !---------------------------------------------------------------------------------!
+         !      Turnover amplitude is a log-linear function of radiation, based on litter  !
+         ! fall data directly related to radiation.                                        !
+         !---------------------------------------------------------------------------------!
+         radto_min = (turnamp_min / radint) ** (1./radslp)
+         radto_max = (turnamp_max / radint) ** (1./radslp)
+         !---------------------------------------------------------------------------------!
+      case default
+         !---------------------------------------------------------------------------------!
+         !      Turnover amplitude is a linear function of radiation, like the original    !
+         ! approach.                                                                       !
+         !---------------------------------------------------------------------------------!
+         radto_min       = (turnamp_min - radint) / radslp
+         radto_max       = (turnamp_max - radint) / radslp
+         !---------------------------------------------------------------------------------!
+      end select
       !------------------------------------------------------------------------------------!
    case default
       !------------------------------------------------------------------------------------!
-      !      Turnover amplitude is a linear function of radiation, like the original       !
-      ! approach.                                                                          !
+      !    Light phenology is disabled.  Set dummy values for minimum and maximum          !
+      ! radiation so the turnover amplitude is never calculated.                           !
       !------------------------------------------------------------------------------------!
-      radto_min       = (turnamp_min - radint) / radslp
-      radto_max       = (turnamp_max - radint) / radslp
+      radto_min = solar
+      radto_max = solar
       !------------------------------------------------------------------------------------!
    end select
    !---------------------------------------------------------------------------------------!


### PR DESCRIPTION
When IPHEN_SCHEME≠3, radiation controls on phenology are disabled, and the code should bypass all calculations. 
The code would still calculate derived parameters, which could lead to floating point exceptions depending on the ED2IN/xml settings. This fix sets the minimum and maximum radiation to the solar constant in ed_params.f90. This will also avoid turnover amplitude to be calculated in in sub-routine update_turnover when light phenology is disabled.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes ---
Shaoqing Liu identified the bug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 