### PR TITLE
Remove SFCWATER_DEPTH from "opti" output files

### DIFF
--- a/ED/src/memory/ed_state_vars.F90
+++ b/ED/src/memory/ed_state_vars.F90
@@ -28538,7 +28538,7 @@ module ed_state_vars
       if (associated(csite%sfcwater_depth)) then
          nvar=nvar+1
            call vtable_edio_r(npts,csite%sfcwater_depth,nvar,igr,init,csite%paglob_id, &
-           var_len,var_len_global,max_ptrs,'SFCWATER_DEPTH :33:hist:opti') 
+           var_len,var_len_global,max_ptrs,'SFCWATER_DEPTH :33:hist') 
          call metadata_edio(nvar,igr,'No metadata available','[NA]','m') 
       end if
 


### PR DESCRIPTION
This fix addresses issue #114 (after a very long time!). Variable SFCWATER_DEPTH is patch-dependent, and its dimensions change whenever the total number of patches change. Variable "FMEAN_SFCW_DEPTH_PY" provides the polygon-average surface water depth and can be safely used in HDF5 files storing multiple times.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [ x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 