### PR TITLE
Minor bug fixes in events.f90

### DIFF
--- a/ED/src/dynamics/events.f90
+++ b/ED/src/dynamics/events.f90
@@ -118,7 +118,7 @@ subroutine prescribed_event(year,doy)
                     call getConfigREAL   ('fol_frac','harvest',j,rval(3),texist)
                     if(.not.texist) rval(3) = 1.0d+0
                     !! storage fraction removed
-                    call getConfigREAL   ('stor_frac','harvest',j,rval(3),texist)
+                    call getConfigREAL   ('stor_frac','harvest',j,rval(4),texist)
                     if(.not.texist) rval(4) = 1.0d+0
 
                     call event_harvest(rval(1),rval(2),rval(3),rval(4))
@@ -137,16 +137,16 @@ subroutine prescribed_event(year,doy)
                     ! nitrogen
                     call getConfigREAL  ('NH4','fertilize',j,rval(1),texist)
                     if(.not.texist) rval(1) = 0.0d+0
-                    call getConfigREAL  ('N03','fertilize',j,rval(1),texist)
+                    call getConfigREAL  ('N03','fertilize',j,rval(2),texist)
                     if(.not.texist) rval(2) = 0.0d+0
                     ! Phosphorus
-                    call getConfigREAL  ('P','fertilize',j,rval(1),texist)
+                    call getConfigREAL  ('P','fertilize',j,rval(3),texist)
                     if(.not.texist) rval(3) = 0.0d+0
                     ! Potassium
-                    call getConfigREAL  ('K','fertilize',j,rval(1),texist)
+                    call getConfigREAL  ('K','fertilize',j,rval(4),texist)
                     if(.not.texist) rval(4) = 0.0d+0
                     ! Calcium
-                    call getConfigREAL  ('Ca','fertilize',j,rval(1),texist)
+                    call getConfigREAL  ('Ca','fertilize',j,rval(5),texist)
                     if(.not.texist) rval(5) = 0.0d+0
 
                     call event_fertilize(rval(1:5))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This pull request fixes a few typos in events.f90, originally raised in issue #353.

## Description
<!--- Describe your changes in detail -->

Because of some typos in event.f90, some elements of vector `rval` could be used without being initialised. This was likely the cause for the Tonzi harvest CI test to fail.

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

@femeunier @pmoorcroft @robkooper 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 