### PR TITLE
Bug fix in ed_max_dims.F90

### DIFF
--- a/ED/src/memory/ed_max_dims.F90
+++ b/ED/src/memory/ed_max_dims.F90
@@ -59,9 +59,6 @@ module ed_max_dims
    integer, parameter :: maxdimp  = maxdim + 2
    integer, parameter :: nxyzpm   = nzpmax * nxpmax * nypmax
    integer, parameter :: maxmach  = 20
-   integer, parameter :: ed_nstyp = 17             ! total # of soil textural classes
-   integer, parameter :: ed_nscol = 21             ! total # of soil colour classes
-   integer, parameter :: ed_nvtyp = 21
 #else
    integer, parameter :: maxgrds = 10
    integer, parameter :: nxpmax  = 666
@@ -73,6 +70,9 @@ module ed_max_dims
    integer, parameter :: nxyzpm  = nzpmax * nxpmax * nypmax
    integer, parameter :: maxmach = 3000
 #endif
+   integer, parameter :: ed_nstyp = 17             ! total # of soil textural classes
+   integer, parameter :: ed_nscol = 21             ! total # of soil colour classes
+   integer, parameter :: ed_nvtyp = 21
    !---------------------------------------------------------------------------------------!
 
 


### PR DESCRIPTION
Variables ed_nstyp, ed_nscol and ed_nvtyp should be defined outside the preprocessor ```#if``` block, they are needed for all types of runs (coupled or offline) and OS.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [x] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 