### PR TITLE
Update radiate_driver.f90

### DIFF
--- a/ED/src/dynamics/radiate_driver.f90
+++ b/ED/src/dynamics/radiate_driver.f90
@@ -714,10 +714,14 @@ module radiate_driver
          !      Community Land Model (CLM). NCAR Technical Note NCAR/TN-478+STR.           !
          !                                                                                 !
          !---------------------------------------------------------------------------------!
-         albedo_sfcw_par = albedo_damp_par + csite%sfcwater_fracliq(ksn,ipa)               &
-                                           * ( snow_albedo_vis - albedo_damp_par )
-         albedo_sfcw_nir = albedo_damp_nir + csite%sfcwater_fracliq(ksn,ipa)               &
-                                           * ( snow_albedo_nir - albedo_damp_nir )
+         !albedo_sfcw_par = albedo_damp_par + csite%sfcwater_fracliq(ksn,ipa)               &!
+         !                                  * ( snow_albedo_vis - albedo_damp_par )         !
+          albedo_sfcw_par = snow_albedo_vis + csite%sfcwater_fracliq(ksn,ipa)               &
+                                           * (  albedo_damp_par - snow_albedo_vis )                                  
+        ! albedo_sfcw_nir = albedo_damp_nir + csite%sfcwater_fracliq(ksn,ipa)               &!
+         !                                  * ( snow_albedo_nir - albedo_damp_nir )          !
+          albedo_sfcw_nir = snow_albedo_nir + csite%sfcwater_fracliq(ksn,ipa)               &
+                                           * (  albedo_damp_nir - snow_albedo_nir )
          !---------------------------------------------------------------------------------!
 
 


### PR DESCRIPTION
a mistake when weighting surface water albedo by water fraction.  In the old equation, when water fraction is 1, the albedo is **snow albedo**, which should have been **damp soil albedo**

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Collaborators
<!--- List collaborators, authors or correspondance on this set of changes --->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
<!--- Also, describe how and in what context model answers should change.  For instance will -->
<!--- changes affect answers when certain modules are turned on, all cases, no cases -->
- [ ] Bug fix (non-breaking change which fixes an issue) <!-- please add issue number -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Other (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.


## Testing :
<!--- denote the hashtag of the base code used in any comparisons--->
<!--- please link or post test results here --->
- [ ] All new and existing tests passed.


<!--this template is from https://www.talater.com/open-source-templates/#/page/99--> 